### PR TITLE
Use the thumbprint generation logic from OAuth2 component

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -237,8 +237,8 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
         boolean trustedCert = false;
         try {
-            String publicKeyOfRegisteredCert = MutualTLSUtil.getThumbPrint(registeredCert);
-            String publicKeyOfRequestCert = MutualTLSUtil.getThumbPrint(requestCert);
+            String publicKeyOfRegisteredCert = MutualTLSUtil.getThumbPrint(registeredCert, null);
+            String publicKeyOfRequestCert = MutualTLSUtil.getThumbPrint(requestCert, null);
             if (StringUtils.equals(publicKeyOfRegisteredCert, publicKeyOfRequestCert)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Client certificate thumbprint matched with the registered certificate thumbprint.");
@@ -250,7 +250,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
                             "registered certificate thumbprint.");
                 }
             }
-        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+        } catch (CertificateEncodingException e) {
             throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_GRANT, "Error occurred while " +
                     "generating certificate thumbprint. Error: " + e.getMessage(), e);
         }
@@ -269,13 +269,9 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
         try {
             return isAuthenticated(getResourceContent(jwksUri), requestCert);
-
         } catch (IOException e) {
             throw new OAuthClientAuthnException(OAuth2ErrorCodes.SERVER_ERROR,
                     "Error occurred while opening HTTP connection for the JWKS URL : " + jwksUri, e);
-        } catch (NoSuchAlgorithmException e) {
-            throw new OAuthClientAuthnException(OAuth2ErrorCodes.SERVER_ERROR,
-                    "Error occurred while generating thumbprint for registered certificate ", e);
         } catch (CertificateException e) {
             throw new OAuthClientAuthnException(OAuth2ErrorCodes.SERVER_ERROR,
                     "Error occurred while parsing certificate retrieved from JWKS endpoint ", e);
@@ -290,12 +286,12 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
      * @return Whether the client was successfully authenticated or not.
      */
     private boolean isAuthenticated(JsonArray resourceArray, X509Certificate requestCert)
-            throws CertificateException, OAuthClientAuthnException, NoSuchAlgorithmException {
+            throws CertificateException, OAuthClientAuthnException {
 
         for (JsonElement jsonElement : resourceArray) {
             JsonElement attributeValue = jsonElement.getAsJsonObject().get(X5T);
             if (attributeValue != null) {
-                if (attributeValue.getAsString().equals(MutualTLSUtil.getThumbPrint(requestCert))) {
+                if (attributeValue.getAsString().equals(MutualTLSUtil.getThumbPrint(requestCert, null))) {
                     if (log.isDebugEnabled()) {
                         log.debug("Client authentication successful using the attribute: " + X5T);
                     }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtil.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtil.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -51,6 +53,7 @@ public class MutualTLSUtil {
     /**
      * Helper method to retrieve the thumbprint of a X509 certificate.
      *
+     * @deprecated Use the method {@link #getThumbPrint(X509Certificate, String)} which honour OAuth2 module.
      * @param cert X509 certificate
      * @return Thumbprint of the X509 certificate
      * @throws NoSuchAlgorithmException
@@ -64,6 +67,26 @@ public class MutualTLSUtil {
         md.update(certEncoded);
         return new String(new Base64(0, null, true).encode(
                 hexify(md.digest()).getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+    }
+
+    /**
+     * Helper method to retrieve the thumbprint of a X509 certificate.
+     *
+     * @param cert X509 certificate
+     * @return Thumbprint of the X509 certificate
+     * @throws NoSuchAlgorithmException
+     * @throws CertificateEncodingException
+     */
+    public static String getThumbPrint(X509Certificate cert, String alias) throws CertificateEncodingException {
+
+        try {
+            return OAuth2Util.getThumbPrint(cert, alias);
+        } catch (IdentityOAuth2Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("An error occurred while getting the thumbprint of the certificate: " + cert.toString());
+            }
+            throw new CertificateEncodingException("Error occurred while getting certificate thumbprint", e);
+        }
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -387,7 +387,8 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
         PowerMockito.doReturn(getJsonArray(testJson)).when(mutualTLSClientAuthenticator1).getResourceContent(any());
         PowerMockito.doReturn(new URL("https://wso2is.com/.well-known/jwks.json"))
                 .when(mutualTLSClientAuthenticator1).getJWKSEndpointOfSP(any(),any());
-        PowerMockito.when(MutualTLSUtil.getThumbPrint(any())).thenReturn("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        PowerMockito.when(MutualTLSUtil.getThumbPrint(any(), any())).thenReturn(
+                "da39a3ee5e6b4b0d3255bfef95601890afd80709");
         PowerMockito.when(httpServletRequest.getAttribute(JAVAX_SERVLET_REQUEST_CERTIFICATE)).thenReturn(certificate);
         assertEquals(mutualTLSClientAuthenticator1
                         .authenticateClient(httpServletRequest, bodyContent, oAuthClientAuthnContext), authenticationResult,

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtilTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtilTest.java
@@ -31,6 +31,8 @@ import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import javax.xml.bind.DatatypeConverter;
+
+import static org.mockito.Matchers.any;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
 import static org.testng.Assert.*;
@@ -81,7 +83,8 @@ public class MutualTLSUtilTest extends PowerMockTestCase {
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate Cert = (X509Certificate) factory.generateCertificate(
                 new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(CERTIFICATE_CONTENT)));
-        assertEquals(MutualTLSUtil.getThumbPrint(Cert), "OTE2OWI4MzQ0MTQ5ZDMzMTk3ZmI2NjNjOGYyNjZhNTZhYzgxZWU5Zg");
+        assertEquals(MutualTLSUtil.getThumbPrint(Cert, null),
+                "OTE2OWI4MzQ0MTQ5ZDMzMTk3ZmI2NjNjOGYyNjZhNTZhYzgxZWU5Zg");
 
     }
 


### PR DESCRIPTION
## Purpose
> Existing code consumes JWKS endpoint response, and compare the thumbprints of the cert received from the JWKS response against the cert received from the request. But the thumbprint generation logic is duplicated across the OAuth component and the OAuth addons component. This PR fixes this issue by making the addon component depends on the OAuth component to reuse thumbprint generation logic.