### PR TITLE
Mutual-TLS Client Certificate-Bound Access Tokens

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/pom.xml
@@ -206,13 +206,19 @@
                             org.apache.commons.lang;version="${apache.commons.lang.package.import.version.range}",
                             org.apache.commons.logging;version="${apache.commons.logging.package.import.version.range}",
                             org.apache.oltu.oauth2.common;version="${apache.oltu.oauth2.common.package.import.version.range}",
+                            org.json;version="${wso2.json}",
                             org.osgi.framework;version="${osgi.framework.package.import.version.range}",
                             org.osgi.service.component;version="${osgi.service.component.package.import.version.range}",
                             org.wso2.carbon.identity.oauth.common;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth.common.exception;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth.event;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.bean;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.client.authentication;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.dto;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.model;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.token;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.token.handlers.grant;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls,
                             org.wso2.carbon.identity.oauth2.util;version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.application.common.model;version="${carbon.identity.package.import.version.range}",
@@ -223,10 +229,14 @@
                             org.apache.commons.codec.binary;
                             version="${org.apache.commons.codec.package.import.version.range}",
                             org.apache.commons.io; version="${org.apache.commons.io.package.import.version.range}",
+                            org.wso2.carbon.identity.core.handler;
+                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.internal,
+                            org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers.*,
+                            org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.*,
                             org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.*,
                             org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.*,
                         </Export-Package>

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.OAuth;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -38,6 +39,7 @@ import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnExc
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.cache.MutualTLSJWKSCache;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.cache.MutualTLSJWKSCacheEntry;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.cache.MutualTLSJWKSCacheKey;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -50,13 +52,14 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil.JAVAX_SERVLET_REQUEST_CERTIFICATE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil.isJwksUriConfigured;
@@ -72,15 +75,6 @@ import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getServiceProvider
 public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticator {
 
     private static final Log log = LogFactory.getLog(MutualTLSClientAuthenticator.class);
-    private static final String X5T = "x5t";
-    private static final String X5C = "x5c";
-    private static final String X509 = "X.509";
-    private static final String HTTP_CONNECTION_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
-            ".HTTPConnectionTimeout";
-    private static final String HTTP_READ_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
-            ".HTTPReadTimeout";
-    private static final String KEYS = "keys";
-    private static final String JWKS_URI = "jwksURI";
 
     /**
      * @param request                 HttpServletRequest which is the incoming request.
@@ -96,6 +90,10 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
         X509Certificate registeredCert;
         URL jwksUri;
+
+        // This value is consumed by MTLS token binding to validate whether the client was authenticated using MTLS.
+        oAuthClientAuthnContext.addParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM,
+                CommonConstants.AUTHENTICATOR_TYPE_MTLS);
 
         // In case if the client ID is not set from canAuthenticate method.
         if (StringUtils.isEmpty(oAuthClientAuthnContext.getClientId())) {
@@ -119,11 +117,15 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
             }
             X509Certificate requestCert;
             Object certObject = request.getAttribute(JAVAX_SERVLET_REQUEST_CERTIFICATE);
+            Optional<X509Certificate> x509certObject = getCertificateFromHeader(request);
+
             if (certObject instanceof X509Certificate[]) {
                 X509Certificate[] cert = (X509Certificate[]) certObject;
                 requestCert = cert[0];
-            } else if (certObject instanceof X509Certificate){
+            } else if (certObject instanceof X509Certificate) {
                 requestCert = (X509Certificate) certObject;
+            } else if (x509certObject.isPresent()) {
+                requestCert = x509certObject.get();
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Could not find client certificate in required format for client: " +
@@ -174,16 +176,32 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
     public boolean canAuthenticate(HttpServletRequest request, Map<String, List> bodyParams,
                                    OAuthClientAuthnContext context) {
 
-        if (clientIdExistsAsParam(bodyParams) && validCertExistsAsAttribute(request)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Client ID exists in request body parameters and a valid certificate found in request " +
-                        "attributes. Hence returning true.");
+        String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
+        if (clientIdExistsAsParam(bodyParams)) {
+            if (validCertExistsAsAttribute(request)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Valid certificate found in the request attribute. Hence returning true.");
+                }
+                return true;
+
+            } else {
+                if (StringUtils.isNotBlank(headerName) && getCertificateFromHeader(request).isPresent()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Valid certificate found from the request header. Hence returning true.");
+                    }
+                    return true;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Mutual TLS authenticator cannot handle this request. " +
+                                "Valid certificate is not found in the request.");
+                    }
+                    return false;
+                }
             }
-            return true;
-        } else {
+        }  else {
             if (log.isDebugEnabled()) {
-                log.debug("Mutual TLS authenticator cannot handle this request. Client id is not available in body " +
-                        "params or valid certificate not found in request attributes.");
+                log.debug("Mutual TLS authenticator cannot handle this request. " +
+                        "Client id is not available in body params.");
             }
             return false;
         }
@@ -205,6 +223,49 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
         Map<String, String> stringContent = getBodyParameters(bodyParams);
         oAuthClientAuthnContext.setClientId(stringContent.get(OAuth.OAUTH_CLIENT_ID));
         return oAuthClientAuthnContext.getClientId();
+    }
+
+    private Optional<X509Certificate> getCertificateFromHeader(HttpServletRequest request) {
+
+        String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
+        String headerString = request.getHeader(headerName);
+
+        if (StringUtils.isNotBlank(headerString)) {
+
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("%s header available in request as %s", headerName, headerString));
+            }
+
+            try {
+                return Optional.of(parseCertificate(headerString));
+            } catch (CertificateException e) {
+                log.error("Unable to parse certificate sent in header", e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Return Certificate for give Certificate Content.
+     *
+     * @param content   Certificate Content
+     * @return X509Certificate X.509 certificate after decoding the certificate content.
+     * @throws CertificateException Certificate Exception.
+     */
+    private X509Certificate parseCertificate(String content) throws CertificateException {
+
+        // Trim extra spaces.
+        String decodedContent = StringUtils.trim(content);
+
+        // Remove Certificate Headers.
+        byte[] decoded = Base64.getDecoder().decode(StringUtils.trim(decodedContent
+                .replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
+                .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY)
+        ));
+
+        return (java.security.cert.X509Certificate) CertificateFactory.getInstance(CommonConstants.X509)
+                .generateCertificate(new ByteArrayInputStream(decoded));
     }
 
     private boolean clientIdExistsAsParam(Map<String, List> contentParam) {
@@ -290,22 +351,22 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
             throws CertificateException, OAuthClientAuthnException {
 
         for (JsonElement jsonElement : resourceArray) {
-            JsonElement attributeValue = jsonElement.getAsJsonObject().get(X5T);
+            JsonElement attributeValue = jsonElement.getAsJsonObject().get(CommonConstants.X5T);
             if (attributeValue != null && attributeValue.getAsString().equals(MutualTLSUtil.getThumbPrint(requestCert,
                     null))) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Client authentication successful using the attribute: " + X5T);
+                    log.debug("Client authentication successful using the attribute: " + CommonConstants.X5T);
                 }
                 return true;
             }
-            attributeValue = jsonElement.getAsJsonObject().get(X5C);
+            attributeValue = jsonElement.getAsJsonObject().get(CommonConstants.X5C);
             if (attributeValue != null) {
-                CertificateFactory factory = CertificateFactory.getInstance(X509);
+                CertificateFactory factory = CertificateFactory.getInstance(CommonConstants.X509);
                 X509Certificate cert = (X509Certificate) factory.generateCertificate(
                         new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(attributeValue.getAsString())));
                 if (authenticate(cert, requestCert)) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Client authentication successful using the attribute: " + X5C);
+                        log.debug("Client authentication successful using the attribute: " + CommonConstants.X5C);
                     }
                     return true;
                 }
@@ -340,8 +401,8 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
                 DefaultResourceRetriever defaultResourceRetriever;
                 defaultResourceRetriever = new DefaultResourceRetriever(
-                        MutualTLSUtil.readHTTPConnectionConfigValue(HTTP_CONNECTION_TIMEOUT_XPATH),
-                        MutualTLSUtil.readHTTPConnectionConfigValue(HTTP_READ_TIMEOUT_XPATH));
+                        MutualTLSUtil.readHTTPConnectionConfigValue(CommonConstants.HTTP_CONNECTION_TIMEOUT_XPATH),
+                        MutualTLSUtil.readHTTPConnectionConfigValue(CommonConstants.HTTP_READ_TIMEOUT_XPATH));
                 if (log.isDebugEnabled()) {
                     log.debug("Fetching JWKS from remote endpoint. JWKS URI: " + jwksUri);
                 }
@@ -356,7 +417,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
                         InputStreamReader inputStreamReader = new InputStreamReader(inputStream)) {
                     JsonElement root = jp.parse(inputStreamReader);
                     JsonObject rootObj = root.getAsJsonObject();
-                    JsonElement keys = rootObj.get(KEYS);
+                    JsonElement keys = rootObj.get(CommonConstants.KEYS);
                     if (keys != null) {
                         return keys.getAsJsonArray();
                     } else {
@@ -377,7 +438,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
     public URL getJWKSEndpointOfSP(ServiceProvider serviceProvider, String clientID) throws OAuthClientAuthnException {
 
         String jwksUri;
-        jwksUri = MutualTLSUtil.getPropertyValue(serviceProvider, JWKS_URI);
+        jwksUri = MutualTLSUtil.getPropertyValue(serviceProvider, CommonConstants.JWKS_URI);
         if (StringUtils.isEmpty(jwksUri)) {
             throw new OAuthClientAuthnException(
                     "jwks endpoint not configured for the service provider for client ID: " + clientID,

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -180,20 +180,20 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
         if (clientIdExistsAsParam(bodyParams)) {
             if (validCertExistsAsAttribute(request)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Valid certificate found in the request attribute. Hence returning true.");
+                    log.debug("A valid certificate was found in the request attribute hence returning true.");
                 }
                 return true;
 
             } else {
                 if (StringUtils.isNotBlank(headerName) && getCertificateFromHeader(request).isPresent()) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Valid certificate found from the request header. Hence returning true.");
+                        log.debug("A valid certificate was found from the request header hence returning true.");
                     }
                     return true;
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Mutual TLS authenticator cannot handle this request. " +
-                                "Valid certificate is not found in the request.");
+                                "A valid certificate could not be found in the request.");
                     }
                     return false;
                 }
@@ -239,7 +239,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
             try {
                 return Optional.of(parseCertificate(headerString));
             } catch (CertificateException e) {
-                log.error("Unable to parse certificate sent in header", e);
+                log.error("Unable to parse the certificate sent in header", e);
             }
         }
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
 
 import com.nimbusds.jose.util.Base64URL;
@@ -15,7 +33,11 @@ import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 public class AbstractMTLSTokenBildingGrantHandler {
 
@@ -62,7 +84,6 @@ public class AbstractMTLSTokenBildingGrantHandler {
         }
         return validateScope;
     }
-
 
     /**
      * Return Certificate for give Certificate Content.

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
@@ -1,0 +1,87 @@
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.X509CertUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.*;
+
+public class AbstractMTLSTokenBildingGrantHandler {
+
+    private static Log log = LogFactory.getLog(MTLSTokenBindingAuthorizationCodeGrantHandler.class);
+
+    public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx, boolean validateScope) throws IdentityOAuth2Exception {
+
+        // Get MTLS certificate from transport headers.
+        HttpRequestHeader[] requestHeaders = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getHttpRequestHeaders();
+        String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
+
+        Optional<HttpRequestHeader> certHeader =
+                Arrays.stream(requestHeaders).filter(httpRequestHeader ->
+                        headerName.equals(httpRequestHeader.getName())).findFirst();
+
+        String authenticatorType = (String) tokReqMsgCtx.getOauth2AccessTokenReqDTO().getoAuthClientAuthnContext()
+                .getParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM);
+        if (certHeader.isPresent() && CommonConstants.AUTHENTICATOR_TYPE_MTLS.equals(authenticatorType)) {
+            Base64URL certThumbprint = null;
+            if (log.isDebugEnabled()) {
+                log.debug("Client MTLS certificate found: " + certHeader);
+            }
+            try {
+                if (certHeader.get().getValue() != null) {
+                    X509Certificate certificate = parseCertificate(certHeader.get().getValue()[0]);
+                    certThumbprint = X509CertUtils.computeSHA256Thumbprint(certificate);
+                }
+            } catch (CertificateException e) {
+                log.error("Error occurred while calculating the thumbprint of the client MTLS certificate", e);
+                return false;
+            }
+
+            // Add certificate thumbprint as a hidden scope of the token.
+            if (certThumbprint != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Client MTLS certificate thumbprint: " + certThumbprint);
+                }
+                String[] scopes = tokReqMsgCtx.getScope();
+                List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
+                scopesList.add(CommonConstants.CERT_THUMBPRINT + "#" + CommonConstants.SHA256_DIGEST_ALGORITHM +
+                        CommonConstants.CERT_THUMBPRINT_SEPARATOR + certThumbprint.toString());
+                tokReqMsgCtx.setScope(scopesList.toArray(new String[scopesList.size()]));
+            }
+        }
+        return validateScope;
+    }
+
+
+    /**
+     * Return Certificate for give Certificate Content.
+     *
+     * @param content Certificate Content.
+     * @return X509Certificate.
+     * @throws CertificateException Certificate Exception.
+     */
+    private static X509Certificate parseCertificate(String content) throws CertificateException {
+
+        // Trim extra spaces.
+        String decodedContent = StringUtils.trim(content);
+
+        // Remove certificate headers.
+        byte[] decoded = Base64.getDecoder().decode(StringUtils.trim(decodedContent
+                .replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
+                .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY)));
+
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(decoded));
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBildingGrantHandler.java
@@ -77,8 +77,9 @@ public class AbstractMTLSTokenBildingGrantHandler {
                 }
                 String[] scopes = tokReqMsgCtx.getScope();
                 List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
-                scopesList.add(CommonConstants.CERT_THUMBPRINT + "#" + CommonConstants.SHA256_DIGEST_ALGORITHM +
-                        CommonConstants.CERT_THUMBPRINT_SEPARATOR + certThumbprint.toString());
+                scopesList.add(CommonConstants.CERT_THUMBPRINT + CommonConstants.SEPARATOR +
+                        CommonConstants.SHA256_DIGEST_ALGORITHM + CommonConstants.CERT_THUMBPRINT_SEPARATOR
+                        + certThumbprint.toString());
                 tokReqMsgCtx.setScope(scopesList.toArray(new String[scopesList.size()]));
             }
         }
@@ -102,7 +103,7 @@ public class AbstractMTLSTokenBildingGrantHandler {
                 .replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
                 .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY)));
 
-        return (X509Certificate) CertificateFactory.getInstance("X.509")
+        return (X509Certificate) CertificateFactory.getInstance(CommonConstants.X509)
                 .generateCertificate(new ByteArrayInputStream(decoded));
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBindingGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBindingGrantHandler.java
@@ -39,9 +39,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-public class AbstractMTLSTokenBildingGrantHandler {
+public class AbstractMTLSTokenBindingGrantHandler {
 
-    private static Log log = LogFactory.getLog(MTLSTokenBindingAuthorizationCodeGrantHandler.class);
+    private static final Log log = LogFactory.getLog(MTLSTokenBindingAuthorizationCodeGrantHandler.class);
 
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx, boolean validateScope) throws IdentityOAuth2Exception {
 
@@ -66,7 +66,9 @@ public class AbstractMTLSTokenBildingGrantHandler {
                     certThumbprint = X509CertUtils.computeSHA256Thumbprint(certificate);
                 }
             } catch (CertificateException e) {
-                log.error("Error occurred while calculating the thumbprint of the client MTLS certificate", e);
+                if (log.isDebugEnabled()) {
+                    log.debug("Error occurred while calculating the thumbprint of the client MTLS certificate", e);
+                }
                 return false;
             }
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationCodeGrantHandler;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This class is used to bound the MTLS certificate of the client to the access token issued. Here, the certificate is
+ * bounded to the access token using a hidden scope.
+ */
+public class MTLSTokenBindingAuthorizationCodeGrantHandler extends AuthorizationCodeGrantHandler {
+
+    @Override
+    public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
+        tokReqMsgCtx.setScope(getReducedResponseScopes(tokReqMsgCtx.getScope()));
+        return oAuth2AccessTokenRespDTO;
+    }
+
+    @Override
+    public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
+
+        boolean validateScope = super.validateScope(tokReqMsgCtx);
+        AbstractMTLSTokenBildingGrantHandler abstractMTLSTokenBildingGrantHandler =
+                new AbstractMTLSTokenBildingGrantHandler();
+        validateScope = abstractMTLSTokenBildingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
+        return validateScope;
+    }
+
+    /**
+     * Remove the certificate thumbprint prefixed scope from the space delimited list of authorized scopes.
+     *
+     * @param scopes Authorized scopes of the token.
+     * @return scopes by removing the custom scope.
+     */
+    private String[] getReducedResponseScopes(String[] scopes) {
+
+        if (ArrayUtils.isNotEmpty(scopes) && scopes.length > 0) {
+            List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            return scopesList.toArray(new String[0]);
+        }
+        return scopes;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
@@ -48,9 +48,9 @@ public class MTLSTokenBindingAuthorizationCodeGrantHandler extends Authorization
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
 
         boolean validateScope = super.validateScope(tokReqMsgCtx);
-        AbstractMTLSTokenBildingGrantHandler abstractMTLSTokenBildingGrantHandler =
-                new AbstractMTLSTokenBildingGrantHandler();
-        validateScope = abstractMTLSTokenBildingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
+        AbstractMTLSTokenBindingGrantHandler abstractMTLSTokenBindingGrantHandler =
+                new AbstractMTLSTokenBindingGrantHandler();
+        validateScope = abstractMTLSTokenBindingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
         return validateScope;
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingAuthorizationCodeGrantHandler.java
@@ -64,7 +64,7 @@ public class MTLSTokenBindingAuthorizationCodeGrantHandler extends Authorization
 
         if (ArrayUtils.isNotEmpty(scopes) && scopes.length > 0) {
             List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
-            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR));
             return scopesList.toArray(new String[0]);
         }
         return scopes;

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
@@ -50,9 +50,9 @@ public class MTLSTokenBindingClientCredentialsGrantHandler extends ClientCredent
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
 
         boolean validateScope = super.validateScope(tokReqMsgCtx);
-        AbstractMTLSTokenBildingGrantHandler abstractMTLSTokenBildingGrantHandler =
-                new AbstractMTLSTokenBildingGrantHandler();
-        validateScope = abstractMTLSTokenBildingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
+        AbstractMTLSTokenBindingGrantHandler abstractMTLSTokenBindingGrantHandler =
+                new AbstractMTLSTokenBindingGrantHandler();
+        validateScope = abstractMTLSTokenBindingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
         return validateScope;
     }
 
@@ -70,7 +70,7 @@ public class MTLSTokenBindingClientCredentialsGrantHandler extends ClientCredent
                 scopesList.add(0, "default");
             }
             scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR));
-            return scopesList.toArray(new String[scopesList.size()]);
+            return scopesList.toArray(new String[0]);
         }
         return scopes;
     }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
@@ -69,7 +69,7 @@ public class MTLSTokenBindingClientCredentialsGrantHandler extends ClientCredent
             if (scopes.length == 1) {
                 scopesList.add(0, "default");
             }
-            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR));
             return scopesList.toArray(new String[scopesList.size()]);
         }
         return scopes;

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingClientCredentialsGrantHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This class is used to bound the MTLS certificate of the client to the access token issued. Here, the certificate is
+ * bounded to the access token using a hidden scope.
+ *
+ * @see <href="https://tools.ietf.org/html/draft-ietf-oauth-mtls-17">IETF OAuth MTLS</>
+ */
+public class MTLSTokenBindingClientCredentialsGrantHandler extends ClientCredentialsGrantHandler {
+
+    @Override
+    public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
+        tokReqMsgCtx.setScope(getReducedResponseScopes(tokReqMsgCtx.getScope()));
+        return oAuth2AccessTokenRespDTO;
+    }
+
+    @Override
+    public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
+
+        boolean validateScope = super.validateScope(tokReqMsgCtx);
+        AbstractMTLSTokenBildingGrantHandler abstractMTLSTokenBildingGrantHandler =
+                new AbstractMTLSTokenBildingGrantHandler();
+        validateScope = abstractMTLSTokenBildingGrantHandler.validateScope(tokReqMsgCtx, validateScope);
+        return validateScope;
+    }
+
+    /**
+     * Remove the certificate thumbprint prefixed scope from the space delimited list of authorized scopes.
+     *
+     * @param scopes Authorized scopes of the token.
+     * @return scopes by removing the custom scope.
+     */
+    private String[] getReducedResponseScopes(String[] scopes) {
+
+        if (ArrayUtils.isNotEmpty(scopes) && scopes.length > 0) {
+            List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
+            if (scopes.length == 1) {
+                scopesList.add(0, "default");
+            }
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            return scopesList.toArray(new String[scopesList.size()]);
+        }
+        return scopes;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * If MTLS token binding is used (MTLSTokenBindingAuthorizationCodeGrantHandler), the certificate of the client is
+ * bounded to the access token using a hidden scope. This class is used to remove the hidden scope from the token
+ * response.
+ *
+ * @see <href="https://tools.ietf.org/html/draft-ietf-oauth-mtls-17">IETF OAuth MTLS</>
+ */
+public class MTLSTokenBindingRefreshGrantHandler extends RefreshGrantHandler {
+
+    private static final Log log = LogFactory.getLog(MTLSTokenBindingRefreshGrantHandler.class);
+
+    @Override
+    public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
+        tokReqMsgCtx.setScope(getReducedResponseScopes(tokReqMsgCtx.getScope()));
+        return oAuth2AccessTokenRespDTO;
+    }
+
+    @Override
+    public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        String[] grantedScopes = tokReqMsgCtx.getScope();
+        if (!super.validateScope(tokReqMsgCtx)) {
+            return false;
+        }
+
+        String[] requestedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();
+        String[] modifiedScopes;
+        if (ArrayUtils.isNotEmpty(requestedScopes)) {
+            if (ArrayUtils.isEmpty(grantedScopes)) {
+                return false;
+            }
+
+            // Add cert hash scope from previously granted scopes.
+            ArrayList<String> requestedScopeList = new ArrayList<>(Arrays.asList(requestedScopes));
+            for (String scope : grantedScopes) {
+                if (isAllowedScope(scope)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Adding custom scope " + scope + " to the requested scopes");
+                    }
+                    requestedScopeList.add(scope);
+                }
+            }
+            modifiedScopes = requestedScopeList.toArray(new String[0]);
+            tokReqMsgCtx.setScope(modifiedScopes);
+        }
+        return true;
+    }
+
+    /**
+     * Remove the certificate thumbprint prefixed scope from the space delimited list of authorized scopes.
+     *
+     * @param scopes Authorized scopes of the token.
+     * @return scopes by removing the custom scope.
+     */
+    private String[] getReducedResponseScopes(String[] scopes) {
+
+        if (scopes != null && scopes.length > 0) {
+            List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            return scopesList.toArray(new String[0]);
+        }
+        return scopes;
+    }
+
+    private boolean isAllowedScope(String scope) {
+
+        return scope.startsWith(CommonConstants.CERT_THUMBPRINT) ||
+                scope.startsWith(CommonConstants.TIMESTAMP_SCOPE_PREFIX);
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
@@ -94,7 +94,7 @@ public class MTLSTokenBindingRefreshGrantHandler extends RefreshGrantHandler {
 
         if (scopes != null && scopes.length > 0) {
             List<String> scopesList = new LinkedList<>(Arrays.asList(scopes));
-            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT));
+            scopesList.removeIf(scope -> scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR));
             return scopesList.toArray(new String[0]);
         }
         return scopes;
@@ -102,7 +102,7 @@ public class MTLSTokenBindingRefreshGrantHandler extends RefreshGrantHandler {
 
     private boolean isAllowedScope(String scope) {
 
-        return scope.startsWith(CommonConstants.CERT_THUMBPRINT) ||
+        return scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR) ||
                 scope.startsWith(CommonConstants.TIMESTAMP_SCOPE_PREFIX);
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandler.java
@@ -73,7 +73,7 @@ public class MTLSTokenBindingRefreshGrantHandler extends RefreshGrantHandler {
             for (String scope : grantedScopes) {
                 if (isAllowedScope(scope)) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Adding custom scope " + scope + " to the requested scopes");
+                        log.debug("Adding custom scope " + scope + " to the requested scopes.");
                     }
                     requestedScopeList.add(scope);
                 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/internal/MutualTLSServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/internal/MutualTLSServiceComponent.java
@@ -24,8 +24,12 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
+import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.MutualTLSClientAuthenticator;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.ISIntrospectionDataProvider;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.IntrospectionResponseInterceptor;
 
 /**
  * TLS Mutual Auth osgi Component.
@@ -37,23 +41,27 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.Mutual
 public class MutualTLSServiceComponent {
 
     private static final Log log = LogFactory.getLog(MutualTLSServiceComponent.class);
-    private BundleContext bundleContext;
 
     @Activate
     protected void activate(ComponentContext context) {
 
         try {
-            // Registering MutualTLSClientAuthenticator as an OSGIService.
-            bundleContext = context.getBundleContext();
+            BundleContext bundleContext = context.getBundleContext();
             MutualTLSClientAuthenticator mutualTLSClientAuthenticator = new MutualTLSClientAuthenticator();
+            IntrospectionResponseInterceptor introspectionResponseInterceptor = new IntrospectionResponseInterceptor();
+            ISIntrospectionDataProvider isIntrospectionDataProvider = new ISIntrospectionDataProvider();
             bundleContext.registerService(OAuthClientAuthenticator.class.getName(), mutualTLSClientAuthenticator,
+                    null);
+            bundleContext.registerService(OAuthEventInterceptor.class.getName(), introspectionResponseInterceptor,
+                    null);
+            bundleContext.registerService(IntrospectionDataProvider.class.getName(), isIntrospectionDataProvider,
                     null);
             if (log.isDebugEnabled()) {
                 log.debug("Mutual TLS bundle is activated");
             }
 
         } catch (Throwable e) {
-            log.error("Error occurred while registering MutualTLSClientAuthenticator.", e);
+            log.error("Error occurred while registering MTLS component.", e);
         }
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProvider.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection;
+
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Introspection data provider.
+ */
+public class ISIntrospectionDataProvider extends AbstractIdentityHandler implements IntrospectionDataProvider {
+
+    @Override
+    public Map<String, Object> getIntrospectionData(OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO,
+                                                    OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO) {
+
+        // Return the properties from the oAuth2IntrospectionResponseDTO back again to the data provider.
+        if (oAuth2IntrospectionResponseDTO.isActive()) {
+            return oAuth2IntrospectionResponseDTO.getProperties();
+        } else {
+            return new HashMap<>();
+        }
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProvider.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProvider.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Introspection data provider.
+ * Introspection data provider to get the modified introspection data.
  */
 public class ISIntrospectionDataProvider extends AbstractIdentityHandler implements IntrospectionDataProvider {
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
@@ -59,7 +59,7 @@ public class IntrospectionResponseInterceptor extends AbstractOAuthEventIntercep
 
             // Iterate the scope list and remove any internal scopes.
             for (String scope : scopeList) {
-                if (scope.startsWith(CommonConstants.CERT_THUMBPRINT)) {
+                if (scope.startsWith(CommonConstants.CERT_THUMBPRINT+ CommonConstants.SEPARATOR)) {
                     String[] certHashScope = scope.split(CommonConstants.CERT_THUMBPRINT_SEPARATOR, 2);
                     cnf = new JSONObject();
                     cnf.put(certHashScope[0].trim(), certHashScope[1].trim());

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+import org.wso2.carbon.identity.oauth.event.AbstractOAuthEventInterceptor;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+
+import java.util.*;
+
+/**
+ * This class is used to modify the token introspection response.
+ */
+public class IntrospectionResponseInterceptor extends AbstractOAuthEventInterceptor {
+
+    private static Log log = LogFactory.getLog(IntrospectionResponseInterceptor.class);
+
+    @Override
+    public void onPostTokenValidation(OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO,
+                                      OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO, Map<String,
+            Object> params) {
+
+        /*
+         Omit the cert thumbprint scope (added by MTLSTokenBindingAuthorizationCodeGrantHandler) from the scopes list
+         and add as a separate parameter in the introspection response as specified under
+         https://tools.ietf.org/html/draft-ietf-oauth-mtls-17.
+        */
+        JSONObject cnf = null;
+        String scopeString = oAuth2IntrospectionResponseDTO.getScope();
+        if (StringUtils.isNotEmpty(scopeString)) {
+            String[] scopeArray = scopeString.trim().split("\\s+");
+            List<String> scopeList = new ArrayList<>(Arrays.asList(scopeArray));
+            List<String> removableScopes = new ArrayList<>();
+
+            // Iterate the scope list and remove any internal scopes.
+            for (String scope : scopeList) {
+                if (scope.startsWith(CommonConstants.CERT_THUMBPRINT)) {
+                    String[] certHashScope = scope.split(CommonConstants.CERT_THUMBPRINT_SEPARATOR, 2);
+                    cnf = new JSONObject();
+                    cnf.put(certHashScope[0].trim(), certHashScope[1].trim());
+
+                    removableScopes.add(scope);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removing the internal scope " + scope + " from introspection response");
+                    }
+                }
+            }
+            scopeList.removeAll(removableScopes);
+            oAuth2IntrospectionResponseDTO.setScope(String.join(" ", scopeList));
+        }
+
+        Map<String, Object> introspectionResponseProperties = oAuth2IntrospectionResponseDTO.getProperties();
+        if (introspectionResponseProperties == null) {
+            introspectionResponseProperties = new HashMap<>();
+        }
+
+        // If the MTLS cert hash is present as a scope, add the cert hash under cnf parameter.
+        if (cnf != null) {
+            introspectionResponseProperties.put(CommonConstants.CONFIRMATION_CLAIM_ATTRIBUTE, cnf);
+        }
+        oAuth2IntrospectionResponseDTO.setProperties(introspectionResponseProperties);
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptor.java
@@ -27,7 +27,11 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
 
 /**
  * This class is used to modify the token introspection response.

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
@@ -22,6 +22,7 @@ public class CommonConstants {
 
     public static final String JWKS_URI = "jwksURI";
     public static final String CERT_THUMBPRINT = "x5t";
+    public static final String SEPARATOR = "#";
     public static final String TIMESTAMP_SCOPE_PREFIX = "TIME_";
     public static final String CERT_THUMBPRINT_SEPARATOR = ":";
     public static final String CONFIRMATION_CLAIM_ATTRIBUTE = "cnf";

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
@@ -1,0 +1,25 @@
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils;
+
+public class CommonConstants {
+
+    public static final String JWKS_URI = "jwksURI";
+    public static final String CERT_THUMBPRINT = "x5t";
+    public static final String TIMESTAMP_SCOPE_PREFIX = "TIME_";
+    public static final String CERT_THUMBPRINT_SEPARATOR = ":";
+    public static final String CONFIRMATION_CLAIM_ATTRIBUTE = "cnf";
+    public static final String SHA256_DIGEST_ALGORITHM = "SHA256";
+    public static final String AUTHENTICATOR_TYPE_PARAM = "authenticatorType";
+    public static final String AUTHENTICATOR_TYPE_MTLS = "mtls";
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
+    public static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
+    public static final String X5T = "x5t";
+    public static final String X5C = "x5c";
+    public static final String X509 = "X.509";
+    public static final String HTTP_CONNECTION_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
+            ".HTTPConnectionTimeout";
+    public static final String HTTP_READ_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
+            ".HTTPReadTimeout";
+    public static final String KEYS = "keys";
+
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils;
 
 public class CommonConstants {

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtil.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtil.java
@@ -42,8 +42,6 @@ import java.security.cert.X509Certificate;
 public class MutualTLSUtil {
 
     private static final Log log = LogFactory.getLog(MutualTLSUtil.class);
-    private static final String JWKS_URI = "jwksURI";
-    private static final String KEYS = "keys";
 
     /**
      * Attribute name for reading client certificate in the request.
@@ -138,7 +136,7 @@ public class MutualTLSUtil {
 
         ServiceProviderProperty[] serviceProviderProperties = serviceProvider.getSpProperties();
         for (ServiceProviderProperty sp : serviceProviderProperties) {
-            if (sp.getName().equals(JWKS_URI) && StringUtils.isNotBlank(sp.getValue())) {
+            if (sp.getName().equals(CommonConstants.JWKS_URI) && StringUtils.isNotBlank(sp.getValue())) {
                 return true;
             }
         }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -55,6 +56,8 @@ import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -62,7 +65,7 @@ import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
 @WithCarbonHome
-@PrepareForTest({OAuth2Util.class, HttpServletRequest.class, MutualTLSUtil.class})
+@PrepareForTest({OAuth2Util.class, HttpServletRequest.class, MutualTLSUtil.class, IdentityUtil.class})
 public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
 
     private MutualTLSClientAuthenticator mutualTLSClientAuthenticator = new MutualTLSClientAuthenticator();
@@ -109,6 +112,29 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
             + "vmO/dYUXGrprjfL7BaCq1eLw9Mx68anuhFYRspmdxoRGidJ6sm/I1ZD5oQEKa1tS\n"
             + "O6eaZWIa6CJF2/e4TMtEPeVEgWqtpLxYzhX2kEgzEXapxMkPwXPfym4I0b2Y0Ag/\n"
             + "7Kun3EsBCgp4r4S9zWAyLA1aJIo63OPDb9Q=";
+
+    private static String CERTIFICATE_CONTENT3 = "-----BEGIN CERTIFICATE-----MIID3" +
+            "TCCAsWgAwIBAgIUJQW8iwYsAbyjc/oHti8DPLJH5ZcwDQYJKoZIhvcNAQELBQAwfjELMA" +
+            "kGA1UEBhMCU0wxEDAOBgNVBAgMB1dlc3Rlcm4xEDAOBgNVBAcMB0NvbG9tYm8xDTALBgN" +
+            "VBAoMBFdTTzIxDDAKBgNVBAsMA0lBTTENMAsGA1UEAwwER2FnYTEfMB0GCSqGSIb3DQEJ" +
+            "ARYQZ2FuZ2FuaUB3c28yLmNvbTAeFw0yMDAzMjQxMjQyMDFaFw0zMDAzMjIxMjQyMDFaM" +
+            "H4xCzAJBgNVBAYTAlNMMRAwDgYDVQQIDAdXZXN0ZXJuMRAwDgYDVQQHDAdDb2xvbWJvMQ" +
+            "0wCwYDVQQKDARXU08yMQwwCgYDVQQLDANJQU0xDTALBgNVBAMMBEdhZ2ExHzAdBgkqhki" +
+            "G9w0BCQEWEGdhbmdhbmlAd3NvMi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK" +
+            "AoIBAQC+reCEYOn2lnWgFsp0TF0R1wQiD9C/N+dnv4xCa0rFiu4njDzWR/8tYFl0koaxX" +
+            "oP0+oGnT07KlkA66q0ztwikLZXphLdCBbJ1hSmNvor48FuSb6DgqWixrUa2LHlpaaV7Rv" +
+            "lmG+IhZEgKDXdS+/tK0hlcgRzENyOEdETDO5fFlKGGuwaGv6/w69h2LTKGu5nyDLF51rj" +
+            "Q18xp026btHC7se/XSlcp3X63xeOIcFv6m84AN2lnV+g8MOfu2wgWtsKaxn4BL64E7nHZ" +
+            "NNLxMRf7GtUm2bl9ydFX4aD1r1Oj4iqFWMNcfQ676Qshk8s7ui3LKWFXwNN/SRD0c/ORt" +
+            "v23AgMBAAGjUzBRMB0GA1UdDgQWBBRDu/vqRafReh4fFHS3Nz4T6u9mUDAfBgNVHSMEGD" +
+            "AWgBRDu/vqRafReh4fFHS3Nz4T6u9mUDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQE" +
+            "BCwUAA4IBAQB7NH51Yj4moEhMonnLUh3eTtf6DUnrpscx6td28rryoDZPfCkJs4VHU9F5" +
+            "0etw54FoHqoIaHp5UIB6l1OsVXytUmwrdxbqW7nfOItYwN1yV093aI2aOeMQYmS+vrPkS" +
+            "kxySP6+wGCWe4gfMgpr6iu9xiWLpnILw5q71gmXWtS900S5aLbllGYe74jkyldLIdhS4T" +
+            "yEBIDgcpZrD8x/Z42al6T/6EANMpvu4Jopisg+uwwkEGSM1I/kjiW+YkWC4oTZ1jMZUWC" +
+            "11WbcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuA" +
+            "xFtF8v+h-----END CERTIFICATE-----";
+
     private static String TEST_JSON_WITH_X5T ="{\n" +
             "  \"keys\" : [ {\n" +
             "    \"e\" : \"AQAB\",\n" +
@@ -249,6 +275,7 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
         List<String> clientIdList = new ArrayList<>();
         clientIdList.add(CLIENT_ID);
         bodyParamsWithClientId.put(OAuth.OAUTH_CLIENT_ID, clientIdList);
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
 
         return new Object[][]{
 
@@ -257,6 +284,9 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
 
                 // Correct  client certificate present with client Id in request body.
                 {getCertificate(CERTIFICATE_CONTENT), bodyParamsWithClientId, buildOAuthClientAuthnContext(CLIENT_ID), true},
+
+                // Incorrect  client certificate present without client Id in request body.
+                {getCertificate("CERTIFICATE_CONTENT"), bodyParamsWithClientId, oAuthClientAuthnContext, false},
 
                 // Correct client certificate not provided.
                 {null, new HashMap<String, List>(), buildOAuthClientAuthnContext(null), false},
@@ -289,7 +319,6 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
         return new Object[][]{
 
                 {getCertificate(CERTIFICATE_CONTENT), new HashMap<String, List>(), false},
-                {null, getBodyContentWithClientId(CLIENT_ID), false},
                 {getCertificate(CERTIFICATE_CONTENT), getBodyContentWithClientId(CLIENT_ID), true},
         };
     }
@@ -301,6 +330,18 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
 
         HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
         PowerMockito.when(httpServletRequest.getAttribute(JAVAX_SERVLET_REQUEST_CERTIFICATE)).thenReturn(certificate);
+        assertEquals(mutualTLSClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent, new
+                OAuthClientAuthnContext()), canHandle, "Expected can authenticate evaluation not received");
+    }
+
+    @Test(dataProvider = "testCanAuthenticateData")
+    public void testCanAuthenticateWithHeader (X509Certificate certificate,
+                                               HashMap<String, List> bodyContent, boolean canHandle) {
+
+        mockStatic(IdentityUtil.class);
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+        when(IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER)).thenReturn("x-wso2-mtls-cert");
+        PowerMockito.when(httpServletRequest.getHeader("x-wso2-mtls-cert")).thenReturn(CERTIFICATE_CONTENT3);
         assertEquals(mutualTLSClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent, new
                 OAuthClientAuthnContext()), canHandle, "Expected can authenticate evaluation not received");
     }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBindingGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/AbstractMTLSTokenBindingGrantHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+import org.mockito.Matchers;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.util.ArrayList;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertFalse;
+
+@PrepareForTest({IdentityUtil.class, CarbonUtils.class, Oauth2ScopeUtils.class, OAuth2Util.class})
+
+@WithCarbonHome
+public class AbstractMTLSTokenBindingGrantHandlerTest extends PowerMockTestCase {
+
+    MTLSTokenBindingAuthorizationCodeGrantHandler mtlsTokenBindingAuthorizationCodeGrantHandler;
+
+    private static String CERTIFICATE_CONTENT = "-----BEGIN CERTIFICATE-----MIID3TCCAsWgAwIBAgIUJQW8iwYsAbyjc/oHti" +
+            "8DPLJH5ZcwDQYJKoZIhvcNAQELBQAwfjELMAkGA1UEBhMCU0wxEDAOBgNVBAgMB1dlc3Rlcm4xEDAOBgNVBAcMB0NvbG9tYm8xDTA" +
+            "LBgNVBAoMBFdTTzIxDDAKBgNVBAsMA0lBTTENMAsGA1UEAwwER2FnYTEfMB0GCSqGSIb3DQEJARYQZ2FuZ2FuaUB3c28yLmNvbTAe" +
+            "Fw0yMDAzMjQxMjQyMDFaFw0zMDAzMjIxMjQyMDFaMH4xCzAJBgNVBAYTAlNMMRAwDgYDVQQIDAdXZXN0ZXJuMRAwDgYDVQQHDAdDb" +
+            "2xvbWJvMQ0wCwYDVQQKDARXU08yMQwwCgYDVQQLDANJQU0xDTALBgNVBAMMBEdhZ2ExHzAdBgkqhkiG9w0BCQEWEGdhbmdhbmlAd3" +
+            "NvMi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+reCEYOn2lnWgFsp0TF0R1wQiD9C/N+dnv4xCa0rFiu4njDz" +
+            "WR/8tYFl0koaxXoP0+oGnT07KlkA66q0ztwikLZXphLdCBbJ1hSmNvor48FuSb6DgqWixrUa2LHlpaaV7RvlmG+IhZEgKDXdS+/tK" +
+            "0hlcgRzENyOEdETDO5fFlKGGuwaGv6/w69h2LTKGu5nyDLF51rjQ18xp026btHC7se/XSlcp3X63xeOIcFv6m84AN2lnV+g8MOfu2" +
+            "wgWtsKaxn4BL64E7nHZNNLxMRf7GtUm2bl9ydFX4aD1r1Oj4iqFWMNcfQ676Qshk8s7ui3LKWFXwNN/SRD0c/ORtv23AgMBAAGjUz" +
+            "BRMB0GA1UdDgQWBBRDu/vqRafReh4fFHS3Nz4T6u9mUDAfBgNVHSMEGDAWgBRDu/vqRafReh4fFHS3Nz4T6u9mUDAPBgNVHRMBAf8" +
+            "EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB7NH51Yj4moEhMonnLUh3eTtf6DUnrpscx6td28rryoDZPfCkJs4VHU9F50etw54Fo" +
+            "HqoIaHp5UIB6l1OsVXytUmwrdxbqW7nfOItYwN1yV093aI2aOeMQYmS+vrPkSkxySP6+wGCWe4gfMgpr6iu9xiWLpnILw5q71gmXW" +
+            "tS900S5aLbllGYe74jkyldLIdhS4TyEBIDgcpZrD8x/Z42al6T/6EANMpvu4Jopisg+uwwkEGSM1I/kjiW+YkWC4oTZ1jMZUWC11W" +
+            "bcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuAxFtF8v+h-----END CERTIFICATE-----";
+
+    @BeforeTest
+    public void setup() {
+    }
+
+    private static OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTOObject() {
+
+        OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTO = new OAuth2AccessTokenReqDTO();
+        oauth2AccessTokenReqDTO.setHttpRequestHeaders(getHttpRequestHeaders
+                (new String[]{"content-type","x-wso2-mutual-auth-cert", "user-agent"},
+                        new String[]{"application/x-www-form-urlencoded", CERTIFICATE_CONTENT, "PostmanRuntime/7.24.0"}));
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.addParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM,
+                CommonConstants.AUTHENTICATOR_TYPE_MTLS);
+        oauth2AccessTokenReqDTO.setoAuthClientAuthnContext(oAuthClientAuthnContext);
+        oauth2AccessTokenReqDTO.setGrantType("Bearer");
+        return oauth2AccessTokenReqDTO;
+    }
+
+    private static HttpRequestHeader[] getHttpRequestHeaders(String[] key, String[] value) {
+
+        ArrayList<HttpRequestHeader> httpRequestHeaders = new ArrayList<>();
+
+        for (int count = 0; count < key.length; count++) {
+            httpRequestHeaders.add(new HttpRequestHeader(key[count], value[count]));
+        }
+        return httpRequestHeaders.toArray(new HttpRequestHeader[0]);
+    }
+
+    @Test
+    public void testValidateScope() throws IdentityOAuth2Exception {
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty((CommonConstants.MTLS_AUTH_HEADER))).thenReturn("x-wso2-mutual-auth-cert");
+        when(IdentityUtil.getIdentityConfigDirPath()).thenReturn(System.
+                getProperty("user.dir") + "/src/test/resources/repository/conf/identity");
+        mtlsTokenBindingAuthorizationCodeGrantHandler = new MTLSTokenBindingAuthorizationCodeGrantHandler();
+
+        mockStatic(Oauth2ScopeUtils.class);
+        when(Oauth2ScopeUtils.validateByApplicationScopeValidator(Matchers.any(OAuthTokenReqMessageContext.class),
+                Matchers.any(OAuthAuthzReqMessageContext.class))).thenReturn(false);
+        OAuthTokenReqMessageContext oAuthTokenReqMessageContext =
+                new OAuthTokenReqMessageContext(oauth2AccessTokenReqDTOObject());
+        oAuthTokenReqMessageContext.setScope(new String[]{"openid"});
+
+        boolean validateScope =
+                mtlsTokenBindingAuthorizationCodeGrantHandler.validateScope(oAuthTokenReqMessageContext);
+        assertFalse(validateScope);
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
+
+
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
+import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.util.ArrayList;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.testng.Assert.assertFalse;
+
+@PrepareForTest({IdentityUtil.class, CarbonUtils.class, Oauth2ScopeUtils.class})
+
+@WithCarbonHome
+public class MTLSTokenBindingRefreshGrantHandlerTest extends PowerMockTestCase {
+
+    MTLSTokenBindingRefreshGrantHandler mtlsTokenBindingRefreshGrantHandler;
+
+    private static String CERTIFICATE_CONTENT = "-----BEGIN CERTIFICATE-----MIID3TCCAsWgAwIBAgIUJQW8iwYsAbyjc/oHti" +
+            "8DPLJH5ZcwDQYJKoZIhvcNAQELBQAwfjELMAkGA1UEBhMCU0wxEDAOBgNVBAgMB1dlc3Rlcm4xEDAOBgNVBAcMB0NvbG9tYm8xDTA" +
+            "LBgNVBAoMBFdTTzIxDDAKBgNVBAsMA0lBTTENMAsGA1UEAwwER2FnYTEfMB0GCSqGSIb3DQEJARYQZ2FuZ2FuaUB3c28yLmNvbTAe" +
+            "Fw0yMDAzMjQxMjQyMDFaFw0zMDAzMjIxMjQyMDFaMH4xCzAJBgNVBAYTAlNMMRAwDgYDVQQIDAdXZXN0ZXJuMRAwDgYDVQQHDAdDb" +
+            "2xvbWJvMQ0wCwYDVQQKDARXU08yMQwwCgYDVQQLDANJQU0xDTALBgNVBAMMBEdhZ2ExHzAdBgkqhkiG9w0BCQEWEGdhbmdhbmlAd3" +
+            "NvMi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+reCEYOn2lnWgFsp0TF0R1wQiD9C/N+dnv4xCa0rFiu4njDz" +
+            "WR/8tYFl0koaxXoP0+oGnT07KlkA66q0ztwikLZXphLdCBbJ1hSmNvor48FuSb6DgqWixrUa2LHlpaaV7RvlmG+IhZEgKDXdS+/tK" +
+            "0hlcgRzENyOEdETDO5fFlKGGuwaGv6/w69h2LTKGu5nyDLF51rjQ18xp026btHC7se/XSlcp3X63xeOIcFv6m84AN2lnV+g8MOfu2" +
+            "wgWtsKaxn4BL64E7nHZNNLxMRf7GtUm2bl9ydFX4aD1r1Oj4iqFWMNcfQ676Qshk8s7ui3LKWFXwNN/SRD0c/ORtv23AgMBAAGjUz" +
+            "BRMB0GA1UdDgQWBBRDu/vqRafReh4fFHS3Nz4T6u9mUDAfBgNVHSMEGDAWgBRDu/vqRafReh4fFHS3Nz4T6u9mUDAPBgNVHRMBAf8" +
+            "EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB7NH51Yj4moEhMonnLUh3eTtf6DUnrpscx6td28rryoDZPfCkJs4VHU9F50etw54Fo" +
+            "HqoIaHp5UIB6l1OsVXytUmwrdxbqW7nfOItYwN1yV093aI2aOeMQYmS+vrPkSkxySP6+wGCWe4gfMgpr6iu9xiWLpnILw5q71gmXW" +
+            "tS900S5aLbllGYe74jkyldLIdhS4TyEBIDgcpZrD8x/Z42al6T/6EANMpvu4Jopisg+uwwkEGSM1I/kjiW+YkWC4oTZ1jMZUWC11W" +
+            "bcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuAxFtF8v+h-----END CERTIFICATE-----";
+
+    @BeforeTest
+    public void setup() {
+    }
+
+    private static OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTOObject() {
+
+        OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTO = new OAuth2AccessTokenReqDTO();
+        oauth2AccessTokenReqDTO.setHttpRequestHeaders(getHttpRequestHeaders
+                (new String[]{"content-type","x-wso2-mutual-auth-cert", "user-agent"},
+                        new String[]{"application/x-www-form-urlencoded", CERTIFICATE_CONTENT, "PostmanRuntime/7.24.0"}));
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.addParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM,
+                CommonConstants.AUTHENTICATOR_TYPE_MTLS);
+        oauth2AccessTokenReqDTO.setoAuthClientAuthnContext(oAuthClientAuthnContext);
+        oauth2AccessTokenReqDTO.setGrantType("Bearer");
+        return oauth2AccessTokenReqDTO;
+    }
+
+    private static HttpRequestHeader[] getHttpRequestHeaders(String[] key, String[] value) {
+
+        ArrayList<HttpRequestHeader> httpRequestHeaders = new ArrayList<>();
+
+        for (int count = 0; count < key.length; count++) {
+            httpRequestHeaders.add(new HttpRequestHeader(key[count], value[count]));
+        }
+        return httpRequestHeaders.toArray(new HttpRequestHeader[0]);
+    }
+
+    @Test
+    public void testValidateScope() throws IdentityOAuth2Exception {
+
+        mockStatic(IdentityUtil.class);
+        PowerMockito.when(IdentityUtil.getProperty((CommonConstants.MTLS_AUTH_HEADER))).
+                thenReturn("x-wso2-mutual-auth-cert");
+        PowerMockito.when(IdentityUtil.getIdentityConfigDirPath()).thenReturn(System.
+                getProperty("user.dir") + "/src/test/resources/repository/conf/identity");
+        mtlsTokenBindingRefreshGrantHandler = new MTLSTokenBindingRefreshGrantHandler();
+        mockStatic(Oauth2ScopeUtils.class);
+        PowerMockito.when(Oauth2ScopeUtils.validateByApplicationScopeValidator
+                (Matchers.any(OAuthTokenReqMessageContext.class),
+                        Matchers.any(OAuthAuthzReqMessageContext.class))).thenReturn(false);
+        OAuthTokenReqMessageContext oAuthTokenReqMessageContext =
+                new OAuthTokenReqMessageContext(oauth2AccessTokenReqDTOObject());
+        oAuthTokenReqMessageContext.setScope(new String[]{"openid"});
+        boolean validateScope =
+                mtlsTokenBindingRefreshGrantHandler.validateScope(oAuthTokenReqMessageContext);
+        assertFalse(validateScope);
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
 
-
 import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProviderTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/ISIntrospectionDataProviderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection;
+
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class ISIntrospectionDataProviderTest extends PowerMockTestCase {
+
+    ISIntrospectionDataProvider isIntrospectionDataProvider;
+
+    @BeforeTest
+    public void setup() {
+
+        isIntrospectionDataProvider = new ISIntrospectionDataProvider();
+    }
+
+
+    @Test
+    public void testGetIntrospectionData() {
+
+        OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO = new OAuth2IntrospectionResponseDTO();
+        OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO2 = new OAuth2IntrospectionResponseDTO();
+        OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO = new OAuth2TokenValidationRequestDTO();
+
+        Map<String, Object> introspectionData = new HashMap<String, Object>();
+        introspectionData.put("nbf", 1585749816);
+        introspectionData.put("active", true);
+        introspectionData.put("iss", "https://server.example.com");
+        introspectionData.put("exp", 1585753416);
+        introspectionData.put("sub", "ty.webb@example.com");
+        introspectionData.put("cnf", new String[]{"x5t#S256", "bwcK0esc3ACC3DB2Y5_lESsXE8o9ltc05O89jdN-dg2"});
+
+        oAuth2IntrospectionResponseDTO.setProperties(introspectionData);
+        oAuth2IntrospectionResponseDTO2.setProperties(new HashMap<String, Object>());
+
+        oAuth2IntrospectionResponseDTO.setActive(true);
+        oAuth2IntrospectionResponseDTO2.setActive(false);
+
+        Map<String, Object> introspectionData2 = new HashMap<String, Object>();
+        assertEquals(isIntrospectionDataProvider.getIntrospectionData(oAuth2TokenValidationRequestDTO,
+                oAuth2IntrospectionResponseDTO), introspectionData,
+                "Expected introspection data not received.");
+
+        assertEquals(isIntrospectionDataProvider.getIntrospectionData(oAuth2TokenValidationRequestDTO,
+                oAuth2IntrospectionResponseDTO2), introspectionData2,
+                "Expected introspection data not received.");
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/introspection/IntrospectionResponseInterceptorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertNotNull;
+
+public class IntrospectionResponseInterceptorTest {
+
+    IntrospectionResponseInterceptor introspectionResponseInterceptor;
+
+    @BeforeTest
+    public void setup() {
+
+        introspectionResponseInterceptor = new IntrospectionResponseInterceptor();
+    }
+
+    @Test
+    public void testGetIntrospectionData() {
+
+        OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO = new OAuth2IntrospectionResponseDTO();
+        OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO2 = new OAuth2IntrospectionResponseDTO();
+        OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO3 = new OAuth2IntrospectionResponseDTO();
+        OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO = new OAuth2TokenValidationRequestDTO();
+
+        Map<String, Object> introspectionData = new HashMap<String, Object>();
+        introspectionData.put("nbf", 1585749816);
+        introspectionData.put("active", true);
+        introspectionData.put("iss", "https://server.example.com");
+        introspectionData.put("exp", 1585753416);
+        introspectionData.put("sub", "ty.webb@example.com");
+        introspectionData.put("cnf", new String[]{"x5t#S256", "bwcK0esc3ACC3DB2Y5_lESsXE8o9ltc05O89jdN-dg2"});
+
+        oAuth2IntrospectionResponseDTO.setScope("openid");
+        oAuth2IntrospectionResponseDTO.setProperties(introspectionData);
+        oAuth2IntrospectionResponseDTO3.setScope("x5t#S256:bwcK0esc3ACC3DB2Y5_lESsXE8o9ltc05O89jdN-dg2");
+
+        introspectionResponseInterceptor.onPostTokenValidation(oAuth2TokenValidationRequestDTO,
+                oAuth2IntrospectionResponseDTO, introspectionData);
+        assertNotNull(oAuth2IntrospectionResponseDTO.getProperties());
+
+        introspectionResponseInterceptor.onPostTokenValidation(oAuth2TokenValidationRequestDTO,
+                oAuth2IntrospectionResponseDTO2, introspectionData);
+        assertNotNull(oAuth2IntrospectionResponseDTO2.getProperties());
+
+        introspectionResponseInterceptor.onPostTokenValidation(oAuth2TokenValidationRequestDTO,
+                oAuth2IntrospectionResponseDTO3, introspectionData);
+        assertNotNull(oAuth2IntrospectionResponseDTO3.getProperties());
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtilTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/MutualTLSUtilTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.io.ByteArrayInputStream;
@@ -41,7 +42,7 @@ import static org.testng.Assert.*;
  * Test class for MutualTLSUtil class.
  */
 @WithCarbonHome
-@PrepareForTest(OAuth2Util.class)
+@PrepareForTest({OAuth2Util.class, IdentityUtil.class})
 public class MutualTLSUtilTest extends PowerMockTestCase {
 
     @Test
@@ -103,5 +104,15 @@ public class MutualTLSUtilTest extends PowerMockTestCase {
         PowerMockito.when(OAuth2Util.getServiceProvider(clientID, SUPER_TENANT_DOMAIN_NAME))
                 .thenReturn(serviceProvider);
         assertTrue(MutualTLSUtil.isJwksUriConfigured(serviceProvider));
+    }
+
+    @Test
+    public void testReadHTTPConnectionConfigValue() {
+
+        PowerMockito.mockStatic(IdentityUtil.class);
+        PowerMockito.when(IdentityUtil.getProperty("path")).thenReturn("xPath");
+        assertEquals(MutualTLSUtil.readHTTPConnectionConfigValue("path"), 0);
+        PowerMockito.when(IdentityUtil.getProperty("path")).thenReturn("123");
+        assertEquals(MutualTLSUtil.readHTTPConnectionConfigValue("path"), 123);
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/resources/testng.xml
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/resources/testng.xml
@@ -28,6 +28,10 @@
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.MutualTLSJWKSCacheKeyTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.MutualTLSJWKSCacheTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtilTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.ISIntrospectionDataProviderTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.IntrospectionResponseInterceptorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers.AbstractMTLSTokenBindingGrantHandlerTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers.MTLSTokenBindingRefreshGrantHandlerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Feature to support Mutual-TLS Client Certificate-Bound Access Tokens.
Resolves: https://github.com/wso2/product-is/issues/8007

Related PR: https://github.com/wso2/carbon-identity-framework/pull/2881

Documentation: [Mutual-TLS Client Certificate-Bound Access Tokens](https://docs.google.com/document/d/1_pJhAH_uv4fnGhzx7EzGr12KWjbZB2QFFSzl4vvg430/edit?usp=sharing)