### PR TITLE
Add PrivilegedUserAuthenticator to support user authentication for Revoke API

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/pom.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.oauth2.clientauth.privilegeduser</artifactId>
+    <packaging>bundle</packaging>
+    <name>Privileged User Authenticator</name>
+    <url>http://wso2.org</url>
+    <parent>
+        <groupId>org.wso2.carbon.extension.identity.oauth.addons</groupId>
+        <artifactId>identity-oauth2-extenstions</artifactId>
+        <version>2.3.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.profile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.securevault</groupId>
+            <artifactId>org.wso2.securevault</artifactId>
+            <exclusions>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <!--Test Dependencies-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-web-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.tomcat.ext</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven.bundle.plugins.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.plugins.version}</version>
+                <configuration>
+                    <source>${maven.plugins.version.source}</source>
+                    <target>${maven.plugins.version.source}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal
+                        </Private-Package>
+                        <Import-Package>
+                            org.osgi.framework;version="${osgi.framework.package.import.version.range}",
+                            org.osgi.service.component;version="${osgi.service.component.package.import.version.range}",
+                            javax.servlet.http;version="${javax.servlet.http.package.import.version.range}",
+                            org.apache.axiom.util.base64; version="${axiom.osgi.version.range}",
+                            org.apache.commons.io; version="${org.apache.commons.io.package.import.version.range}",
+                            org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.oauth2.client.authentication;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.bean;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth.common;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth.common.exception;version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.application.authentication.framework.*,
+                            org.wso2.carbon.identity.core.handler;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.model;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.model;
+                            version="${carbon.identity.package.import.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal,
+                            org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.*;
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <!--<argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5006</argLine>-->
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!--Exception classes in this component are used not used within this-->
+                        <!--component, but in dependent oauth components. Constant classes only have private
+                        constructors. Hence they excluding them in coverage reports-->
+                        <exclude>**/CommonConstants.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.3</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resource.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <!-- here the phase you need -->
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/test/resources/</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/pom.xml
@@ -188,6 +188,7 @@
                             javax.servlet.http;version="${javax.servlet.http.package.import.version.range}",
                             org.apache.axiom.util.base64; version="${axiom.osgi.version.range}",
                             org.apache.commons.io; version="${org.apache.commons.io.package.import.version.range}",
+                            org.apache.commons.logging; version="${apache.commons.logging.package.import.version.range}",
                             org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser;
+
+import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.client.authentication.AbstractOAuthClientAuthenticator;
+import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal.PrivilegedUserAuthenticatorServiceHolder;
+import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.utils.CommonConstants;
+import org.wso2.carbon.user.api.AuthorizationManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
+
+/**
+ * Authenticator that can authenticate user and allow access for a user to access a OAuth endpoint on behalf of an
+ * application.
+ */
+public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticator {
+
+    private static final Log LOG = LogFactory.getLog(PrivilegedUserAuthenticator.class);
+    private String userPermission;
+
+    public PrivilegedUserAuthenticator() {
+
+        userPermission = CommonConstants.DEFAULT_ADMIN_PERMISSION;
+    }
+
+    /**
+     * Authenticate the user and returns true if the user has permission to authenticate this api.
+     *
+     * @param httpServletRequest      HttpServletRequest.
+     * @param map                     Map of request body.
+     * @param oAuthClientAuthnContext OAuth2 Client Authentication Context
+     * @return True if the user can be authenticated and has required permission.
+     * @throws OAuthClientAuthnException
+     */
+    public boolean authenticateClient(HttpServletRequest httpServletRequest, Map<String, List> map,
+                                      OAuthClientAuthnContext oAuthClientAuthnContext)
+            throws OAuthClientAuthnException {
+
+        String[] credentials = extractCredentialsFromReq(getCredentials(map));
+        String userName = credentials[0];
+        String password = credentials[1];
+        return isUserAuthorized(userName, password);
+    }
+
+    /**
+     * Returns true if this authenticator can authenticate this request, else returns false.
+     *
+     * @param httpServletRequest      HttpServletRequest.
+     * @param map                     Map of request body.
+     * @param oAuthClientAuthnContext OAuth Client Authentication context.
+     * @return True if this authenticator can authenticate this request.
+     */
+    public boolean canAuthenticate(HttpServletRequest httpServletRequest, Map<String, List> map,
+                                   OAuthClientAuthnContext oAuthClientAuthnContext) {
+
+        if (isUserCredentialsExists(map) && httpServletRequest.getRequestURI().equals(CommonConstants.REVOKE_ENDPOINT)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Authorization header exists. Hence this authenticator can authenticate this request");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves the client ID which is extracted from incoming request.
+     *
+     * @param request                 HttpServletRequest.
+     * @param bodyParams              Body parameter map of the incoming request.
+     * @param oAuthClientAuthnContext OAuthClientAuthentication context.
+     * @return Client ID of the OAuth2 client.
+     * @throws OAuthClientAuthnException OAuth client authentication Exception.
+     */
+    @Override
+    public String getClientId(HttpServletRequest request, Map<String, List> bodyParams, OAuthClientAuthnContext
+            oAuthClientAuthnContext) throws OAuthClientAuthnException {
+
+        Map<String, String> stringContent = getBodyParameters(bodyParams);
+        oAuthClientAuthnContext.setClientId(stringContent.get(OAuth.OAUTH_CLIENT_ID));
+        return oAuthClientAuthnContext.getClientId();
+    }
+
+    @Override
+    public String getName() {
+
+        return "PrivilegedUserAuthenticator";
+    }
+
+    /**
+     * If this authenticator is configured in the configuration level, then it will be enabled. If not, if will be
+     * disabled.
+     *
+     * @return True if this is enabled, else returns false.
+     */
+    public boolean isEnabled() {
+
+        IdentityEventListenerConfig identityEventListenerConfig =
+                IdentityUtil.readEventListenerProperty(AbstractIdentityHandler.class.getName(),
+                        this.getClass().getName());
+        return identityEventListenerConfig != null && Boolean.parseBoolean(identityEventListenerConfig.getEnable());
+    }
+
+    /**
+     * Validates the authorization header and returns true if the header present.
+     *
+     * @param map RequestBody
+     * @return True if the authorization header present, else returns false.
+     */
+    private boolean isUserCredentialsExists(Map<String, List> map) {
+
+        return isNotEmpty(getCredentials(map));
+    }
+
+    /**
+     * Returns Authorization header from the request.
+     *
+     * @param map HttpRequestBody
+     * @return Authorization header
+     */
+    private String getCredentials(Map<String, List> map) {
+
+        Map<String, String> stringContent = getBodyParameters(map);
+        return stringContent.get(CommonConstants.CREDENTIALS);
+    }
+
+    /**
+     * Extract Credentials of the user from authorization header present in the request.
+     *
+     * @param encodedCredentials AuthorizationHeader
+     * @return Array contains username and password.
+     * @throws OAuthClientAuthnException
+     */
+    private static String[] extractCredentialsFromReq(String encodedCredentials)
+            throws OAuthClientAuthnException {
+
+        if (isNotEmpty(encodedCredentials)) {
+            byte[] decodedBytes = Base64Utils.decode(encodedCredentials);
+            String userNamePassword = new String(decodedBytes, Charsets.UTF_8);
+            String[] credentials = userNamePassword.split(CommonConstants.CREDENTIAL_SEPARATOR);
+            if (credentials.length == CommonConstants.CREDENTIAL_LENGTH) {
+                return credentials;
+            }
+        }
+        String errMsg = "Error decoding credentials param.";
+        throw new OAuthClientAuthnException(errMsg, OAuth2ErrorCodes.INVALID_REQUEST);
+    }
+
+    /**
+     * Returns true if the user can be authenticated and has enough permission to access the api on behalf of the
+     * client.
+     *
+     * @param userName UserName.
+     * @param password Password.
+     * @return True if the user can be authenticated and has enough permission to access the api on behalf of
+     * the client, else returns false.
+     * @throws OAuthClientAuthnException
+     */
+    private boolean isUserAuthorized(String userName, String password) throws OAuthClientAuthnException {
+
+        int tenantId = IdentityTenantUtil.getTenantIdOfUser(userName);
+        String tenantDomain = MultitenantUtils.getTenantDomain(userName);
+        User user = new User();
+        user.setUserName(MultitenantUtils.getTenantAwareUsername(userName));
+        user.setTenantDomain(tenantDomain);
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+
+            UserRealm userRealm = PrivilegedUserAuthenticatorServiceHolder.getInstance().getRealmService().
+                    getTenantUserRealm(tenantId);
+            if (userRealm != null) {
+                UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+                boolean isUserAuthenticated = userStoreManager.authenticate(MultitenantUtils.
+                        getTenantAwareUsername(userName), password);
+                if (isUserAuthenticated) {
+                    String domain = UserCoreUtil.getDomainName(userRealm.getRealmConfiguration());
+                    if (StringUtils.isNotBlank(domain)) {
+                        user.setUserStoreDomain(domain);
+                    }
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Basic Authentication successful for the user: " + userName);
+                    }
+                    return handleAuthorization(user, tenantId);
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("User authentication was not successful for the user: " + userName);
+                }
+            } else {
+                String errorMessage = "Error occurred while trying to load the user realm for the tenant: " +
+                        tenantId;
+                LOG.error(errorMessage);
+                throw new OAuthClientAuthnException(errorMessage, OAuth2ErrorCodes.ACCESS_DENIED);
+            }
+
+        } catch (UserStoreException | OAuthClientAuthnException e) {
+            String errorMessage = "Error occurred while trying to authenticate user: " + userName;
+            LOG.error(errorMessage);
+            throw new OAuthClientAuthnException(errorMessage, OAuth2ErrorCodes.ACCESS_DENIED);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+        return false;
+    }
+
+    /**
+     * Authorize the user from userstore and check whether the user has the required permission. Returns true if user
+     * has required permission to access the resource.
+     *
+     * @param user     User.
+     * @param tenantId TenantId.
+     * @return Returns true if user has required permission to access the resource.
+     * @throws OAuthClientAuthnException
+     */
+    private boolean handleAuthorization(User user, int tenantId) throws OAuthClientAuthnException {
+
+        try {
+            RealmService realmService = PrivilegedUserAuthenticatorServiceHolder.getInstance().getRealmService();
+            UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("User permission to access to API is configured as: " + userPermission);
+            }
+            AuthorizationManager authorizationManager = userRealm.getAuthorizationManager();
+            boolean isUserAuthorized = authorizationManager.isUserAuthorized(UserCoreUtil.addDomainToName(
+                    user.getUserName(), user.getUserStoreDomain()), userPermission,
+                    CarbonConstants.UI_PERMISSION_ACTION);
+            if (LOG.isDebugEnabled()) {
+                String msg = String.format("User is %s to access this resource.", isUserAuthorized ? "authorized" :
+                        "unauthorized");
+                LOG.debug(msg);
+            }
+            return isUserAuthorized;
+        } catch (UserStoreException e) {
+            String errorMessage = "Error occurred while trying to authorize user: " + user.getUserName();
+            LOG.error(errorMessage);
+            throw new OAuthClientAuthnException(errorMessage, OAuth2ErrorCodes.ACCESS_DENIED);
+        }
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
@@ -98,7 +98,7 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
 
         if (isUserCredentialsExists(map) && httpServletRequest.getRequestURI().equals(CommonConstants.REVOKE_ENDPOINT)) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Authorization header exists. Hence this authenticator can authenticate this request");
+                LOG.debug("User credentials body param exists. Hence this authenticator can authenticate this request");
             }
             return true;
         }

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceComponent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenticator;
+import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.PrivilegedUserAuthenticator;
+import org.wso2.carbon.user.core.service.RealmService;
+
+
+@Component(
+        name = "org.wso2.carbon.identity.oauth2.clientauth.privilegeduser",
+        immediate = true
+)
+public class PrivilegedUserAuthenticatorServiceComponent {
+
+    private static final Log log = LogFactory.getLog(PrivilegedUserAuthenticatorServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext ctxt) {
+
+        try {
+            PrivilegedUserAuthenticator privilegedUserAuthenticator = new PrivilegedUserAuthenticator();
+            BundleContext bundleContext = ctxt.getBundleContext();
+            bundleContext.registerService(OAuthClientAuthenticator.class.getName(), privilegedUserAuthenticator,
+                    null);
+            if (log.isDebugEnabled()) {
+                log.debug("PrivilegedUserAuthenticator is activated");
+            }
+        } catch (Exception e) {
+            log.fatal("Error while activating the PrivilegedUserAuthenticator. ", e);
+        }
+    }
+
+    protected void deactivate(ComponentContext ctxt) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("PrivilegedUserAuthenticator is deactivated.");
+        }
+    }
+
+    @Reference(
+            name = "user.realmservice.default",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        PrivilegedUserAuthenticatorServiceHolder.getInstance().setRealmService(realmService);
+        if (log.isDebugEnabled()) {
+            log.debug("RealmService is set in the custom token builder bundle.");
+        }
+    }
+    protected void unsetRealmService(RealmService realmService) {
+
+        PrivilegedUserAuthenticatorServiceHolder.getInstance().setRealmService(null);
+        if (log.isDebugEnabled()) {
+            log.debug("RealmService is unset in the custom token builder bundle.");
+        }
+    }
+}
+

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal;
+
+import org.wso2.carbon.user.core.service.RealmService;
+
+public class PrivilegedUserAuthenticatorServiceHolder {
+
+    private RealmService realmService = null;
+    private static PrivilegedUserAuthenticatorServiceHolder instance = new PrivilegedUserAuthenticatorServiceHolder();
+
+    public static PrivilegedUserAuthenticatorServiceHolder getInstance() {
+
+        return instance;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/utils/CommonConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.utils;
+
+public class CommonConstants {
+
+    public static final String CREDENTIAL_SEPARATOR = ":";
+    public static final String DEFAULT_ADMIN_PERMISSION = "/permission/admin/manage/application/revoke";
+    public static final int CREDENTIAL_LENGTH = 2;
+    public static final String REVOKE_ENDPOINT = "/oauth2/revoke";
+    public static final String CREDENTIALS = "credentials";
+
+}

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticatorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser;
+
+import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.axis2.transport.http.HTTPConstants;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal.PrivilegedUserAuthenticatorServiceHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+import org.wso2.carbon.user.api.AuthorizationManager;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+
+@PrepareForTest({
+        HttpServletRequest.class,
+        OAuth2Util.class,
+        IdentityTenantUtil.class,
+        PrivilegedUserAuthenticatorServiceHolder.class,
+        UserCoreUtil.class,
+})
+@WithCarbonHome
+public class PrivilegedUserAuthenticatorTest extends PowerMockIdentityBaseTest {
+
+    private PrivilegedUserAuthenticator privilegedUserAuthenticator = new PrivilegedUserAuthenticator();
+    private static final String CREDENTIALS = "credentials";
+    private static final String FAULT_CREDENTIALS_PARAM = "faultcredentials";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String CLIENT_ID = "KrVLov4Bl3natUksF2HmWsdw684a";
+    private static final String REVOKE_ENDPOINT = "/oauth2/revoke";
+
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private UserStoreManager userStoreManager;
+    @Mock
+    private PrivilegedUserAuthenticatorServiceHolder privilegedUserAuthenticatorServiceHolder;
+    @Mock
+    private RealmConfiguration mockedRealmConfiguration;
+    @Mock
+    private AuthorizationManager authorizationManager;
+
+    @DataProvider(name = "testCanAuthenticateData")
+    public Object[][] testCanAuthenticateData() {
+
+        return new Object[][]{
+
+                // Correct request parameter name with valid username and password.
+                {CREDENTIALS, getBase64EncodedUserAuthHeader(USERNAME,
+                        PASSWORD), new HashMap<String, List>(), true},
+
+                // Fault  request parameter name with valid username and password.
+                {FAULT_CREDENTIALS_PARAM, getBase64EncodedUserAuthHeader(USERNAME,
+                        PASSWORD), new HashMap<String, List>(), false},
+
+                // No credential parameter
+                { null, null, new HashMap<String, List>(), false},
+
+
+        };
+    }
+
+    @Test(dataProvider = "testCanAuthenticateData")
+    public void testCanAuthenticate(String paramName, String paramValue, HashMap<String, List> bodyContent, boolean
+            canHandle) throws Exception {
+
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+        List<String> userCredentialContent = new ArrayList<>();
+        userCredentialContent.add(paramName);
+        bodyContent.put(paramName, userCredentialContent);
+        when(httpServletRequest.getRequestURI()).thenReturn(REVOKE_ENDPOINT);
+        PowerMockito.when(httpServletRequest.getHeader(paramName)).thenReturn(paramValue);
+        assertEquals(privilegedUserAuthenticator.canAuthenticate(httpServletRequest, bodyContent, new
+                OAuthClientAuthnContext()), canHandle, "Expected can authenticate evaluation not received");
+    }
+
+    @Test
+    public void testGetName() throws Exception {
+
+        assertEquals("PrivilegedUserAuthenticator", privilegedUserAuthenticator.getName(),
+                "PrivilegedUserAuthenticator name has changed.");
+    }
+
+    @Test
+    public void testGetClientId() throws Exception {
+
+        Map<String, List> bodyContent = new HashMap<>();
+        List<String> clientIDContent = new ArrayList<>();
+        clientIDContent.add(CLIENT_ID);
+        bodyContent.put("client_id", clientIDContent);
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+        String clientId = privilegedUserAuthenticator.getClientId(httpServletRequest, bodyContent,
+                new OAuthClientAuthnContext());
+        assertEquals(clientId, "KrVLov4Bl3natUksF2HmWsdw684a", "The expected client id is not found.");
+    }
+
+
+    @DataProvider(name = "testClientAuthnData")
+    public Object[][] testClientAuthnData() {
+
+        return new Object[][]{
+
+                // Correct authorization header present with correct encoding
+                {HTTPConstants.HEADER_AUTHORIZATION, getBase64EncodedUserAuthHeader(USERNAME,
+                        PASSWORD), new HashMap<String, List>(), buildOAuthClientAuthnContext(CLIENT_ID),
+                        true},
+        };
+    }
+
+    @Test(dataProvider = "testClientAuthnData")
+    public void testAuthenticateClient(String headerName, String headerValue, HashMap<String, List> bodyContent,
+                                       Object oAuthClientAuthnContextObj,
+                                       boolean authenticationResult) throws Exception {
+
+        OAuthClientAuthnContext oAuthClientAuthnContext = (OAuthClientAuthnContext) oAuthClientAuthnContextObj;
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantIdOfUser(anyString())).thenReturn(-1234);
+
+        mockStatic(PrivilegedUserAuthenticatorServiceHolder.class);
+        when(PrivilegedUserAuthenticatorServiceHolder.getInstance()).thenReturn(privilegedUserAuthenticatorServiceHolder);
+
+        mockStatic(UserCoreUtil.class);
+
+        List<String> userCredentialContent = new ArrayList<>();
+        userCredentialContent.add(getBase64EncodedUserAuthHeader(USERNAME, PASSWORD));
+        bodyContent.put(CREDENTIALS, userCredentialContent);
+
+        when(privilegedUserAuthenticatorServiceHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.authenticate(anyString(), any())).thenReturn(true);
+
+        when(userRealm.getRealmConfiguration()).thenReturn(mockedRealmConfiguration);
+        when(UserCoreUtil.getDomainName(mockedRealmConfiguration)).thenReturn("PRIMARY");
+
+        when(userRealm.getAuthorizationManager()).thenReturn(authorizationManager);
+        when(authorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(true);
+
+        PowerMockito.when(httpServletRequest.getHeader(headerName)).thenReturn(headerValue);
+        assertEquals(privilegedUserAuthenticator.authenticateClient(httpServletRequest, bodyContent,
+                oAuthClientAuthnContext), authenticationResult, "Expected client authentication result was not " +
+                "received");
+    }
+
+    private  String getBase64EncodedUserAuthHeader(String userName, String password) {
+
+        return "User " + Base64Utils.encode((userName + ":" + password).getBytes());
+    }
+
+    private OAuthClientAuthnContext buildOAuthClientAuthnContext(String clientId) {
+
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setClientId(clientId);
+        return oAuthClientAuthnContext;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceComponentTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/internal/PrivilegedUserAuthenticatorServiceComponentTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal;
+
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.PrivilegedUserAuthenticator;
+
+import java.util.Dictionary;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+@PrepareForTest(BundleContext.class)
+public class PrivilegedUserAuthenticatorServiceComponentTest {
+
+
+    @Mock
+    BundleContext bundleContext;
+
+    @Mock
+    private ComponentContext context;
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    @BeforeClass
+    public void setUp() throws Exception {
+
+        initMocks(this);
+    }
+
+    @Test
+    public void testActivate() throws Exception {
+
+        mockStatic(BundleContext.class);
+        when(context.getBundleContext()).thenReturn(bundleContext);
+
+        final String[] serviceName = new String[1];
+
+        doAnswer(new Answer<Object>() {
+
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                PrivilegedUserAuthenticator privilegedUserAuthenticator =
+                        (PrivilegedUserAuthenticator) invocation.getArguments()[1];
+                serviceName[0] = privilegedUserAuthenticator.getClass().getName();
+                return null;
+            }
+        }).when(bundleContext).registerService(anyString(), any(PrivilegedUserAuthenticator.class), any(Dictionary.class));
+
+        PrivilegedUserAuthenticatorServiceComponent mutualTLSServiceComponent = new PrivilegedUserAuthenticatorServiceComponent();
+        mutualTLSServiceComponent.activate(context);
+
+        assertEquals(PrivilegedUserAuthenticator.class.getName(), serviceName[0], "error");
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/resources/testng.xml
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-Oauth-PrivilegedUser-Authenticator">
+    <test name="Tests" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="debug"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.PrivilegedUserAuthenticatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal.PrivilegedUserAuthenticatorServiceComponentTest"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>component/org.wso2.carbon.identity.oauth2.validators.xacml</module>
         <module>features/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.feature</module>
         <module>features/org.wso2.carbon.identity.oauth2.validators.xacml.server.feature</module>
+        <module>component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser</module>
     </modules>
 
     <profiles>
@@ -424,6 +425,7 @@
         <identity.inbound.auth.oauth.imp.pkg.version>[6.2.18,7.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
+        <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <org.apache.oltu.oauth2.common.version>1.0.1</org.apache.oltu.oauth2.common.version>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9026

This authenticator can be invoked during revoke API flow when encoded user credentials are sent as a request body param as shown below.

`credentials=base64encoded<tenant_qualified_username:password>`

**Example:** 
```
curl -k -v -d "credentials=VEVTVC91c2VyMUBhYmMuY29tOnVzZXIx&token=2606bd3b-f497-3d13-96bf-2d8bbdaf52e5&token_type_hint=access_token&client_id=9e8S8L1lkippHTPIwhfXSl6IWGUa"  -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/revoke

```
Add the following config in the deployment.toml file to enable this authenticator.


```
[[event_listener]]
id = "privileged_user_authenticator"
type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
name = "org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.PrivilegedUserAuthenticator"
order = "200"
```

The privileged user should have the following permission to revoke the access token **"/permission/admin/manage/application/revoke"**

For troubleshooting,

```
logger.org-wso2-carbon-identity-oauth2-privilegeduser.name=org.wso2.carbon.identity.oauth2.clientauth.privilegeduser
logger.org-wso2-carbon-identity-oauth2-privilegeduser.level=DEBUG
```