### PR TITLE
 Change username and password as required request parameters and Update READMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,51 @@ org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt-<version>-SNAPSHOT.
     ```curl -v POST -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d 'client_id=<clientid>&grant_type=authorization_code&code=$CODE&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=<private_key_jwt>&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token```
 
 8. Refer https://docs.wso2.com/display/IS550/Private+Key+JWT+Client+Authentication+for+OIDC for more details
+
+### 02. Privileged User Authenticator
+
+This authenticator is used to authenticate a privileged user and allow the permission to revoke accesstokens
+ on behalf of an application.
+
+
+**Deploying and Configuring  artifacts**
+1. Execute "mvn clean install" to build the project.
+
+2. Place component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/target/
+org.wso2.carbon.identity.oauth2.clientauth.privilegeduser-<version>-SNAPSHOT.jar in the
+ <IS_HOME>/repository/component/dropins directory.
+3.The cURL command below can be used to revoke an accesstoken.
+ 
+ ```
+ curl -k -v -d "username=<username>&password=<password>&token=<token>&token_type_hint
+ =<token_type>&client_id=<client-id>"  -H "Content-Type: application/x-www-form-urlencoded" https
+://localhost
+:9443/oauth2/revoke
+ ```
+
+Sample Request:
+
+```
+curl -k -v -d "username=admin@abc.com&password=admin&token=9f716139-4493-3635-abec-7498c2e6cba8&token_type_hint
+=access_token&client_id=9e8S8L1lkippHTPIwhfXSl6IWGUa"  -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/revoke
+```
+
+**Deployment.toml Config**
+
+Add the following config in the deployment.toml file to enable this authenticator.
+```
+[[event_listener]]
+id = "privileged_user_authenticator"
+type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+name = "org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.PrivilegedUserAuthenticator"
+order = "200"
+```
+
+
+**User Permission**
+
+- The privileged user should have the following permission to revoke the access token `/permission/admin/manage
+/application/revoke`
+- Create the above permission
+- Assign that permission to the privileged user
+

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
@@ -76,9 +76,12 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
             throws OAuthClientAuthnException {
 
         String[] credentials = getCredentials(map);
-        String userName = credentials[0];
-        String password = credentials[1];
-        return isUserAuthorized(userName, password);
+        if (credentials != null) {
+            String userName = credentials[0];
+            String password = credentials[1];
+            return isUserAuthorized(userName, password);
+        }
+        return false;
     }
 
     /**
@@ -147,7 +150,7 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
      */
     private boolean isUserCredentialsExists(Map<String, List> map) {
 
-        if(getCredentials(map) == null){
+        if (getCredentials(map) == null) {
             return false;
         }
         return CommonConstants.CREDENTIAL_LENGTH == getCredentials(map).length;
@@ -157,14 +160,14 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
      * Returns username and password from the request.
      *
      * @param map HttpRequestBody
-     * @return Array of username and passoword if they exist. Else returns null.
+     * @return Array of username and password if they exist. Else returns null.
      */
     private String[] getCredentials(Map<String, List> map) {
 
         Map<String, String> stringContent = getBodyParameters(map);
-        String username = stringContent.get("username");
-        String password = stringContent.get("password");
-        if(username != null && password != null){
+        String username = stringContent.get(CommonConstants.USERNAME_PARAM);
+        String password = stringContent.get(CommonConstants.PASSWORD_PARAM);
+        if (username != null && password != null) {
             return new String[]{username, password};
         }
         return null;

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticator.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser;
 
-import org.apache.axiom.util.base64.Base64Utils;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -50,8 +48,6 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
-
 /**
  * Authenticator that can authenticate user and allow access for a user to access a OAuth endpoint on behalf of an
  * application.
@@ -79,7 +75,7 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
                                       OAuthClientAuthnContext oAuthClientAuthnContext)
             throws OAuthClientAuthnException {
 
-        String[] credentials = extractCredentialsFromReq(getCredentials(map));
+        String[] credentials = getCredentials(map);
         String userName = credentials[0];
         String password = credentials[1];
         return isUserAuthorized(userName, password);
@@ -144,48 +140,34 @@ public class PrivilegedUserAuthenticator extends AbstractOAuthClientAuthenticato
     }
 
     /**
-     * Validates the authorization header and returns true if the header present.
+     * Checks whether the username nad password exists in body param and returns true if present.
      *
      * @param map RequestBody
-     * @return True if the authorization header present, else returns false.
+     * @return True if the username and password present, else returns false.
      */
     private boolean isUserCredentialsExists(Map<String, List> map) {
 
-        return isNotEmpty(getCredentials(map));
+        if(getCredentials(map) == null){
+            return false;
+        }
+        return CommonConstants.CREDENTIAL_LENGTH == getCredentials(map).length;
     }
 
     /**
-     * Returns Authorization header from the request.
+     * Returns username and password from the request.
      *
      * @param map HttpRequestBody
-     * @return Authorization header
+     * @return Array of username and passoword if they exist. Else returns null.
      */
-    private String getCredentials(Map<String, List> map) {
+    private String[] getCredentials(Map<String, List> map) {
 
         Map<String, String> stringContent = getBodyParameters(map);
-        return stringContent.get(CommonConstants.CREDENTIALS);
-    }
-
-    /**
-     * Extract Credentials of the user from authorization header present in the request.
-     *
-     * @param encodedCredentials AuthorizationHeader
-     * @return Array contains username and password.
-     * @throws OAuthClientAuthnException
-     */
-    private static String[] extractCredentialsFromReq(String encodedCredentials)
-            throws OAuthClientAuthnException {
-
-        if (isNotEmpty(encodedCredentials)) {
-            byte[] decodedBytes = Base64Utils.decode(encodedCredentials);
-            String userNamePassword = new String(decodedBytes, Charsets.UTF_8);
-            String[] credentials = userNamePassword.split(CommonConstants.CREDENTIAL_SEPARATOR);
-            if (credentials.length == CommonConstants.CREDENTIAL_LENGTH) {
-                return credentials;
-            }
+        String username = stringContent.get("username");
+        String password = stringContent.get("password");
+        if(username != null && password != null){
+            return new String[]{username, password};
         }
-        String errMsg = "Error decoding credentials param.";
-        throw new OAuthClientAuthnException(errMsg, OAuth2ErrorCodes.INVALID_REQUEST);
+        return null;
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/main/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/utils/CommonConstants.java
@@ -20,10 +20,10 @@ package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.utils;
 
 public class CommonConstants {
 
-    public static final String CREDENTIAL_SEPARATOR = ":";
     public static final String DEFAULT_ADMIN_PERMISSION = "/permission/admin/manage/application/revoke";
     public static final int CREDENTIAL_LENGTH = 2;
     public static final String REVOKE_ENDPOINT = "/oauth2/revoke";
-    public static final String CREDENTIALS = "credentials";
+    public static final String USERNAME_PARAM = "username";
+    public static final String PASSWORD_PARAM = "password";
 
 }


### PR DESCRIPTION
## Purpose
This has following changes:

1. Change username and password as required request

Previously we used encoded credentials similar to Basic Authorization Header and passed it as `credentials` param in the request body. But this may introduce additional overhead since the developers need to encode them. So passing username and password as separate body param will reduce the overhead of developers. This approach will be similar to passing credentials in password grant

2.  Update READMe

As a part of https://github.com/wso2/product-is/issues/9026

