### PR TITLE
Fixed DPoP token binding issues

### DIFF
--- a/component/org.wso2.carbon.identity.dpop/README.md
+++ b/component/org.wso2.carbon.identity.dpop/README.md
@@ -39,9 +39,6 @@ properties.header_validity_period = 90
 [[oauth.custom_token_validator]]
 type = "dpop"
 class = "org.wso2.carbon.identity.dpop.validators.DPoPTokenValidator"
-
-[oauth.grant_type.uma_ticket]
-retrieve_uma_permission_info_through_introspection = true
 ```
 4. Restart the Identity Server.
 5. Sign in to the Management Console and navigate to
@@ -98,6 +95,7 @@ curl --location --request GET 'https://localhost:9443/scim2/Users' \
 --header 'Authorization: DPoP 1ce0fc0a-c830-307a-aafc-d25fdc4063ee'
 ```
 &emsp;&ensp;Here, **Authorization Header Value = DPoP {access-token}**
+
 4. Revoke Token :
 
 ```

--- a/component/org.wso2.carbon.identity.dpop/README.md
+++ b/component/org.wso2.carbon.identity.dpop/README.md
@@ -35,7 +35,7 @@ name="org.wso2.carbon.identity.dpop.listener.OauthDPoPInterceptorHandlerProxy"
 order = 13
 enable = true
 properties.header_validity_period = 90
-properties.skip_dpop_validation_in_revoke = "false"
+properties.skip_dpop_validation_in_revoke = "true"
 
 [[oauth.custom_token_validator]]
 type = "dpop"

--- a/component/org.wso2.carbon.identity.dpop/README.md
+++ b/component/org.wso2.carbon.identity.dpop/README.md
@@ -35,6 +35,7 @@ name="org.wso2.carbon.identity.dpop.listener.OauthDPoPInterceptorHandlerProxy"
 order = 13
 enable = true
 properties.header_validity_period = 90
+properties.skip_dpop_validation_in_revoke = "false"
 
 [[oauth.custom_token_validator]]
 type = "dpop"

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/constant/DPoPConstants.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/constant/DPoPConstants.java
@@ -46,7 +46,7 @@ public class DPoPConstants {
     public static final String AUTHORIZATION_HEADER = "authorization";
     public static final String OAUTH_REVOKE_ENDPOINT = "/oauth2/revoke";
     public static final String SKIP_DPOP_VALIDATION_IN_REVOKE = "skip_dpop_validation_in_revoke";
-    public static final boolean DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE = false;
+    public static final boolean DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE = true;
 
     /**
      * This class defines SQLQueries.

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/constant/DPoPConstants.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/constant/DPoPConstants.java
@@ -45,6 +45,8 @@ public class DPoPConstants {
     public static final String JWK_THUMBPRINT = "jkt";
     public static final String AUTHORIZATION_HEADER = "authorization";
     public static final String OAUTH_REVOKE_ENDPOINT = "/oauth2/revoke";
+    public static final String SKIP_DPOP_VALIDATION_IN_REVOKE = "skip_dpop_validation_in_revoke";
+    public static final boolean DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE = false;
 
     /**
      * This class defines SQLQueries.

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/token/binder/DPoPBasedTokenBinder.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/token/binder/DPoPBasedTokenBinder.java
@@ -277,7 +277,7 @@ public class DPoPBasedTokenBinder extends AbstractTokenBinder {
 
         String skipDPoPValidationInRevokeValue = skipDPoPValidationInRevokeObject.toString().trim();
 
-        if (!(skipDPoPValidationInRevokeValue.equals("true") || skipDPoPValidationInRevokeValue.equals("false"))) {
+        if (!("true".equals(skipDPoPValidationInRevokeValue) || "false".equals(skipDPoPValidationInRevokeValue))) {
             log.info("Configured, skip dpop validation in revoke value is set to an invalid value. Hence the " +
                     "default value will be used.");
             return DPoPConstants.DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE;

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/token/binder/DPoPBasedTokenBinder.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/token/binder/DPoPBasedTokenBinder.java
@@ -22,9 +22,12 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.dpop.constant.DPoPConstants;
 import org.wso2.carbon.identity.dpop.dao.DPoPTokenManagerDAO;
 import org.wso2.carbon.identity.dpop.internal.DPoPDataHolder;
+import org.wso2.carbon.identity.dpop.listener.OauthDPoPInterceptorHandlerProxy;
 import org.wso2.carbon.identity.dpop.util.Utils;
 import org.wso2.carbon.identity.dpop.validators.DPoPHeaderValidator;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -202,6 +205,11 @@ public class DPoPBasedTokenBinder extends AbstractTokenBinder {
     private boolean validateDPoPHeader(Object request, TokenBinding tokenBinding) throws IdentityOAuth2Exception,
             ParseException {
 
+        if (((HttpServletRequest) request).getRequestURI().equals(DPoPConstants.OAUTH_REVOKE_ENDPOINT) &&
+                skipDPoPValidationInRevoke()){
+            return true;
+        }
+
         if (!((HttpServletRequest) request).getRequestURI().equals(DPoPConstants.OAUTH_REVOKE_ENDPOINT) &&
                 !((HttpServletRequest) request).getHeader(DPoPConstants.AUTHORIZATION_HEADER)
                         .startsWith(DPoPConstants.OAUTH_DPOP_HEADER)) {
@@ -255,5 +263,27 @@ public class DPoPBasedTokenBinder extends AbstractTokenBinder {
             }
         }
         return supportedGrantTypesSet.toArray(new String[supportedGrantTypesSet.size()]);
+    }
+
+    private static boolean skipDPoPValidationInRevoke() {
+
+        Object skipDPoPValidationInRevokeObject = IdentityUtil.readEventListenerProperty
+                        (AbstractIdentityHandler.class.getName(), OauthDPoPInterceptorHandlerProxy.class.getName())
+                .getProperties().get(DPoPConstants.SKIP_DPOP_VALIDATION_IN_REVOKE);
+
+        if (skipDPoPValidationInRevokeObject == null){
+            return DPoPConstants.DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE;
+        }
+
+        String skipDPoPValidationInRevokeValue = skipDPoPValidationInRevokeObject.toString().trim();
+
+        if (!(skipDPoPValidationInRevokeValue.equals("true") || skipDPoPValidationInRevokeValue.equals("false"))) {
+            log.info("Configured, skip dpop validation in revoke value is set to an invalid value. Hence the " +
+                    "default value will be used.");
+            return DPoPConstants.DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE;
+
+        }
+
+        return Boolean.parseBoolean(skipDPoPValidationInRevokeValue);
     }
 }

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
@@ -278,15 +278,21 @@ public class DPoPHeaderValidator {
     }
 
     private static int getDPoPValidityPeriod() {
+        Object validityPeriodObject = IdentityUtil.readEventListenerProperty
+                (AbstractIdentityHandler.class.getName(), OauthDPoPInterceptorHandlerProxy.class.getName())
+                .getProperties().get(DPoPConstants.VALIDITY_PERIOD);
 
-        String validityPeriodValue = IdentityUtil.readEventListenerProperty
-                        (AbstractIdentityHandler.class.getName(), OauthDPoPInterceptorHandlerProxy.class.getName())
-                .getProperties().get(DPoPConstants.VALIDITY_PERIOD).toString();
+        if (validityPeriodObject == null){
+            return DPoPConstants.DEFAULT_HEADER_VALIDITY;
+        }
+
+        String validityPeriodValue = validityPeriodObject.toString();
+
         if (StringUtils.isNotBlank(validityPeriodValue)) {
             if (StringUtils.isNumeric(validityPeriodValue)) {
                 return Integer.parseInt(validityPeriodValue.trim()) * 1000;
             }
-            log.info("Configured dpop validity period is set to a invalid value.Hence the default validity " +
+            log.info("Configured dpop validity period is set to an invalid value.Hence the default validity " +
                     "period will be used.");
             return DPoPConstants.DEFAULT_HEADER_VALIDITY;
         }

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
@@ -292,7 +292,7 @@ public class DPoPHeaderValidator {
             if (StringUtils.isNumeric(validityPeriodValue)) {
                 return Integer.parseInt(validityPeriodValue.trim()) * 1000;
             }
-            log.info("Configured dpop validity period is set to an invalid value.Hence the default validity " +
+            log.info("Configured dpop validity period is set to an invalid value. Hence the default validity " +
                     "period will be used.");
             return DPoPConstants.DEFAULT_HEADER_VALIDITY;
         }


### PR DESCRIPTION
## Purpose
> Added Skip DPoP header validation in revoke endpoint configurability from deployment.toml.
> Fixed NullPointerException when missing deployment.toml configurations issue for dpop_listener properties.
> Fixed and Added entries to README
