### PR TITLE
Add FAPI and CIBA multiple audience support

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -40,6 +40,11 @@ public class Constants {
     public static final String ISSUER_CLAIM = "iss";
     public static final String PRIVATE_KEY_JWT = "signedJWT";
     public static final String JWKS_URI = "jwksURI";
+    public static final String PS256_ALG = "PS256";
+    public static final String ES256_ALG = "ES256";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String OAUTH_CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
+    public static final String OAUTH2_CIBA_ENDPOINT = "/oauth2/ciba";
 
     public static class SQLQueries {
 

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -42,8 +42,6 @@ public class Constants {
     public static final String JWKS_URI = "jwksURI";
     public static final String PS256_ALG = "PS256";
     public static final String ES256_ALG = "ES256";
-    public static final String GRANT_TYPE = "grant_type";
-    public static final String OAUTH_CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
     public static final String OAUTH2_CIBA_ENDPOINT = "/oauth2/ciba";
 
     public static class SQLQueries {

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -43,10 +43,8 @@ import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Const
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.DEFAULT_AUDIENCE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.EXPIRATION_TIME_CLAIM;
-import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.ISSUER_CLAIM;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.JWT_ID_CLAIM;
-import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_CIBA_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_ASSERTION;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_ASSERTION_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_BEARER_GRANT_TYPE;
@@ -203,7 +201,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
      * @param httpServletRequest Request
      * @return Whether the call is CIBA specific
      */
-    private boolean isBackchannelCall(HttpServletRequest httpServletRequest) {
+    protected boolean isBackchannelCall(HttpServletRequest httpServletRequest) {
         // Although CIBA call uses jwt-bearer grant type, special audience values should be set
         return Constants.OAUTH2_CIBA_ENDPOINT.equals(httpServletRequest.getContextPath() +
                 httpServletRequest.getPathInfo());

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -43,8 +43,10 @@ import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Const
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.DEFAULT_AUDIENCE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.EXPIRATION_TIME_CLAIM;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.ISSUER_CLAIM;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.JWT_ID_CLAIM;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_CIBA_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_ASSERTION;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_ASSERTION_TYPE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_JWT_BEARER_GRANT_TYPE;
@@ -68,6 +70,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
         int rejectBeforePeriod = DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
         boolean preventTokenReuse = true;
         String tokenEPAlias = DEFAULT_AUDIENCE;
+        ArrayList<String> validAudiences = new ArrayList<>();
         try {
             if (isNotEmpty(properties.getProperty(TOKEN_ENDPOINT_ALIAS))) {
                 tokenEPAlias = properties.getProperty(TOKEN_ENDPOINT_ALIAS);
@@ -78,7 +81,8 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
             if (isNotEmpty(properties.getProperty(REJECT_BEFORE_IN_MINUTES))) {
                 rejectBeforePeriod = Integer.parseInt(properties.getProperty(REJECT_BEFORE_IN_MINUTES));
             }
-            jwtValidator = createJWTValidator(tokenEPAlias, preventTokenReuse, rejectBeforePeriod);
+            validAudiences.add(tokenEPAlias);
+            jwtValidator = createJWTValidator(validAudiences, preventTokenReuse, rejectBeforePeriod);
         } catch (NumberFormatException e) {
             log.warn("Invalid PrivateKeyJWT Validity period found in the configuration. Using default value: " +
                     rejectBeforePeriod);
@@ -98,7 +102,8 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
     public boolean authenticateClient(HttpServletRequest httpServletRequest, Map<String, List> bodyParameters,
                                       OAuthClientAuthnContext oAuthClientAuthnContext) throws OAuthClientAuthnException {
 
-        return jwtValidator.isValidAssertion(getSignedJWT(bodyParameters, oAuthClientAuthnContext));
+        return jwtValidator.isValidAssertion(getSignedJWT(bodyParameters, oAuthClientAuthnContext),
+                oAuthClientAuthnContext, isBackchannelCall(httpServletRequest));
     }
 
     /**
@@ -119,7 +124,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
     }
 
     /**
-     * Retrievs the client ID which is extracted from the JWT.
+     * Retrieves the client ID which is extracted from the JWT.
      *
      * @param httpServletRequest
      * @param bodyParameters
@@ -175,10 +180,11 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
         return OAUTH_JWT_BEARER_GRANT_TYPE.equals(clientAssertionType) && isNotEmpty(clientAssertion);
     }
 
-    private JWTValidator createJWTValidator(String tokenEPAlias, boolean preventTokenReuse, int rejectBefore) {
+    private JWTValidator createJWTValidator(ArrayList<String> validAudiences, boolean preventTokenReuse
+            , int rejectBefore) {
 
-        return new JWTValidator(preventTokenReuse, tokenEPAlias, rejectBefore, null, populateMandatoryClaims(),
-                DEFAULT_ENABLE_JTI_CACHE);
+        return new JWTValidator(preventTokenReuse, validAudiences, rejectBefore, null,
+                populateMandatoryClaims(), DEFAULT_ENABLE_JTI_CACHE);
     }
 
     private List<String> populateMandatoryClaims() {
@@ -190,5 +196,16 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
         mandatoryClaims.add(EXPIRATION_TIME_CLAIM);
         mandatoryClaims.add(JWT_ID_CLAIM);
         return mandatoryClaims;
+    }
+
+    /**
+     * Check if the request is CIBA specific
+     * @param httpServletRequest Request
+     * @return Whether the call is CIBA specific
+     */
+    private boolean isBackchannelCall(HttpServletRequest httpServletRequest) {
+        // Although CIBA call uses jwt-bearer grant type, special audience values should be set
+        return Constants.OAUTH2_CIBA_ENDPOINT.equals(httpServletRequest.getContextPath() +
+                httpServletRequest.getPathInfo());
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -69,13 +69,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_TOKEN_EP_URL;
-import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.GRANT_TYPE;
-import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.OAUTH_CIBA_GRANT_TYPE;
 
 /**
  * This class is used to validate the JWT which is coming along with the request.

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -64,8 +64,8 @@ public class PrivateKeyJWTClientAuthenticatorTest {
     @Mock
     HttpServletRequest httpServletRequest;
 
-    OAuthClientAuthnContext oAuthClientAuthnContext =new OAuthClientAuthnContext();
-
+    @Mock
+    OAuthClientAuthnContext oAuthClientAuthnContext;
     KeyStore clientKeyStore;
     Key key1;
     String audience;

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt;
 
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
@@ -31,7 +33,6 @@ import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
-import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
 
 import java.security.Key;
@@ -64,10 +65,11 @@ public class PrivateKeyJWTClientAuthenticatorTest {
     @Mock
     HttpServletRequest httpServletRequest;
 
-    @Mock
-    OAuthClientAuthnContext oAuthClientAuthnContext;
+    OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
     KeyStore clientKeyStore;
+
     Key key1;
+    
     String audience;
 
     @BeforeClass
@@ -94,7 +96,7 @@ public class PrivateKeyJWTClientAuthenticatorTest {
     }
 
     @Test
-    public void testcanAuthenticate() throws IdentityOAuth2Exception {
+    public void testCanAuthenticate() throws IdentityOAuth2Exception {
 
         Map<String, List> bodyContent = new HashMap<>();
         List<String> assertion = new ArrayList<>();
@@ -107,6 +109,17 @@ public class PrivateKeyJWTClientAuthenticatorTest {
         boolean received = privateKeyJWTClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent,
                 oAuthClientAuthnContext);
         assertEquals(received, true, "A valid request refused to authenticate.");
+
+    }
+
+    @Test
+    public void testIsBackchannelCall(){
+
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+        Mockito.when(httpServletRequest.getContextPath()).thenReturn("/oauth2");
+        Mockito.when(httpServletRequest.getPathInfo()).thenReturn("/ciba");
+        boolean isBackchannelCall = privateKeyJWTClientAuthenticator.isBackchannelCall(httpServletRequest);
+        assertEquals(isBackchannelCall, true, "A valid backchannel call identified");
 
     }
 }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/util/JWTTestUtil.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/util/JWTTestUtil.java
@@ -235,8 +235,8 @@ public class JWTTestUtil {
         } catch (NumberFormatException e) {
             rejectBeforePeriod = Constants.DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
         }
-
-        return new JWTValidator(preventTokenReuse, validAudience, rejectBeforePeriod, validIssuer, mandatoryClaims
+        ArrayList<String> validAudiences = new ArrayList<>();
+        return new JWTValidator(preventTokenReuse, validAudiences, rejectBeforePeriod, validIssuer, mandatoryClaims
                 , cacheUsedJTI);
     }
 }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -244,10 +244,10 @@ public class JWTValidatorTest {
         try {
             JWTValidator jwtValidator = getJWTValidator((Properties) properties);
             SignedJWT signedJWT = SignedJWT.parse(jwt);
-            assertEquals(jwtValidator.isValidAssertion(signedJWT),
+            assertEquals(jwtValidator.isValidAssertion(signedJWT, false),
                     expected, errorMsg);
             if (((Properties) properties).getProperty(MANDATORY) != null) {
-                assertEquals(jwtValidator.isValidAssertion(null),
+                assertEquals(jwtValidator.isValidAssertion(null, false),
                         expected, errorMsg);
             }
 
@@ -262,7 +262,7 @@ public class JWTValidatorTest {
 
         try {
             JWTValidator jwtValidator = getJWTValidator(new Properties());
-            jwtValidator.isValidAssertion(null);
+            jwtValidator.isValidAssertion(null, false);
         } catch (OAuthClientAuthnException e) {
             assertFalse(false, "Validation should fail when token is null");
         }

--- a/component/org.wso2.carbon.identity.oauth2.validators.xacml/src/test/java/org/wso2/carbon/identity/oauth2/validators/XACMLScopeValidatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.validators.xacml/src/test/java/org/wso2/carbon/identity/oauth2/validators/XACMLScopeValidatorTest.java
@@ -71,7 +71,7 @@ import static org.testng.Assert.assertTrue;
         AuthorizationGrantCache.class})
 @PowerMockIgnore({"javax.xml.*"})
 @WithCarbonHome
-public class XACMLScopeValidatorTest extends IdentityBaseTest {
+public class XACMLScopeValidatorTest {
 
     private static final String ADMIN_USER = "admin_user";
     private static final String APP_NAME = "SP_APP";

--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
-        <identity.inbound.auth.oauth.version>6.7.70</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.7.173-SNAPSHOT</identity.inbound.auth.oauth.version><!-- Version to be updated after inbound PR is merged-->
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.1.0)</org.wso2.carbon.database.utils.version.range>
 


### PR DESCRIPTION
## Purpose
>  This PR adds FAPI validation and multiple audience support to pass OIDC-FAPI:CIBA conformance suites. Following improvements have been added.
- If FAPI for CIBA is enabled only "PS256" and "ES256" can be used as JWT signing algorithms.
- Add support for token endpoint and ciba endpoint as valid audiences for CIBA(/oauth2/ciba) call(Acc. to spec requirement)

Issue: 
https://github.com/wso2-support/product-is/pull/965
https://github.com/wso2-enterprise/wso2-iam-internal/issues/25

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Related PRs
Framework : https://github.com/wso2-support/carbon-identity-framework/pull/2371
Product IS : https://github.com/wso2-support/product-is/pull/965
Inbound Auth : https://github.com/wso2-support/identity-inbound-auth-oauth/pull/1213

Note: Merge after all related PRs
