### PR TITLE
Increase database util version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.inbound.auth.oauth.version>6.7.70</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
-        <org.wso2.carbon.database.utils.version.range>[2.0.0,2.1.0)</org.wso2.carbon.database.utils.version.range>
+        <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>
 
         <identity.inbound.auth.oauth.imp.pkg.version>[6.2.18,7.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
         <identity.carbon.auth.rest.version>1.4.47</identity.carbon.auth.rest.version>


### PR DESCRIPTION
## Purpose
> Identity server 6.0 start up fails due to carbon-utils version range mismatch for the DPoP bundle. The version range is increased to fix the startup issue.

<img width="1440" alt="Screenshot 2022-10-11 at 06 02 26" src="https://user-images.githubusercontent.com/35717390/194972337-d272dfdc-eaf2-481c-b847-ab02b07190f7.png">
