### PR TITLE
Imporve Insert dataquery by adding update facility

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -47,5 +47,10 @@ public class Constants {
         public static final String GET_JWT = "SELECT EXP_TIME,TIME_CREATED FROM IDN_OIDC_JTI WHERE JWT_ID =?";
         public static final String INSERT_JWD_ID = "INSERT INTO IDN_OIDC_JTI (JWT_ID, EXP_TIME, TIME_CREATED)" +
                 "VALUES (?,?,?)";
+        public static final String INSERT_OR_UPDATE_JWT_ID = "MERGE IDN_OIDC_JTI T USING  (VALUES (?,?,?)) " +
+                "S (JWT_ID, EXP_TIME, TIME_CREATED) ON T.JWT_ID = S.JWT_ID WHEN MATCHED THEN " +
+                "UPDATE SET EXP_TIME = S.EXP_TIME, TIME_CREATED = S.TIME_CREATED WHEN NOT MATCHED THEN " +
+                "INSERT (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (S.JWT_ID, S.EXP_TIME,S.TIME_CREATED);";
+
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.client.authentication.AbstractOAuthClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.validator.JWTValidator;
 
 import java.text.ParseException;
@@ -78,6 +79,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
             if (isNotEmpty(properties.getProperty(REJECT_BEFORE_IN_MINUTES))) {
                 rejectBeforePeriod = Integer.parseInt(properties.getProperty(REJECT_BEFORE_IN_MINUTES));
             }
+            JWTServiceDataHolder.getInstance().setPreventTokenReuse(preventTokenReuse);
             jwtValidator = createJWTValidator(tokenEPAlias, preventTokenReuse, rejectBeforePeriod);
         } catch (NumberFormatException e) {
             log.warn("Invalid PrivateKeyJWT Validity period found in the configuration. Using default value: " +

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -126,7 +127,11 @@ public class JWTStorageManager {
         PreparedStatement preparedStatement = null;
         try {
             connection = IdentityDatabaseUtil.getDBConnection();
-            preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_JWD_ID);
+            if (JWTServiceDataHolder.getInstance().isPreventTokenReuse()){
+                preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_JWD_ID);
+            } else {
+                preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_OR_UPDATE_JWT_ID);
+            }
             preparedStatement.setString(1, jti);
             Timestamp timestamp = new Timestamp(timeCreated);
             Timestamp expTimestamp = new Timestamp(expTime);

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
@@ -28,6 +28,18 @@ public class JWTServiceDataHolder {
     private RealmService realmService = null;
     public static JWTServiceDataHolder instance = new JWTServiceDataHolder();
 
+    public boolean preventTokenReuse = true;
+
+    public boolean isPreventTokenReuse() {
+
+        return preventTokenReuse;
+    }
+
+    public void setPreventTokenReuse(boolean preventTokenReuse) {
+
+        this.preventTokenReuse = preventTokenReuse;
+    }
+
     public static JWTServiceDataHolder getInstance() {
 
         return instance;


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/15415

Fix:
Rather than having only Insert query,
if `PreventTokenReuse==false`
then we are using Update if exists query to support the behavior

I used a data holder to store and populate the `PreventTokenReuse configuration component-wise.
