### PR TITLE
 Imporve Insert dataquery by adding update facility #97 

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -47,10 +47,10 @@ public class Constants {
         public static final String GET_JWT = "SELECT EXP_TIME,TIME_CREATED FROM IDN_OIDC_JTI WHERE JWT_ID =?";
         public static final String INSERT_JWD_ID = "INSERT INTO IDN_OIDC_JTI (JWT_ID, EXP_TIME, TIME_CREATED)" +
                 "VALUES (?,?,?)";
-        public static final String INSERT_OR_UPDATE_JWT_ID_MSSQL_OR_DB2 = "MERGE IDN_OIDC_JTI T USING  " +
+        public static final String INSERT_OR_UPDATE_JWT_ID_MSSQL_OR_DB2 = "MERGE INTO IDN_OIDC_JTI T USING  " +
                 "(VALUES (?,?,?)) S (JWT_ID, EXP_TIME, TIME_CREATED) ON T.JWT_ID = S.JWT_ID WHEN MATCHED THEN " +
                 "UPDATE SET EXP_TIME = S.EXP_TIME, TIME_CREATED = S.TIME_CREATED WHEN NOT MATCHED THEN " +
-                "INSERT (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (S.JWT_ID, S.EXP_TIME,S.TIME_CREATED);";
+                "INSERT (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (S.JWT_ID, S.EXP_TIME,S.TIME_CREATED)";
 
         public static final String INSERT_OR_UPDATE_JWT_ID_MYSQL = "INSERT INTO IDN_OIDC_JTI " +
                 "(JWT_ID, EXP_TIME, TIME_CREATED) VALUES (?, ?, ?)  " +
@@ -70,6 +70,5 @@ public class Constants {
                 "WHEN MATCHED THEN UPDATE SET EXP_TIME = ? , TIME_CREATED = ? " +
                 "WHEN NOT MATCHED THEN INSERT (JWT_ID, EXP_TIME, TIME_CREATED) " +
                 " VALUES (?, ?, ?)";
-
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -47,10 +47,29 @@ public class Constants {
         public static final String GET_JWT = "SELECT EXP_TIME,TIME_CREATED FROM IDN_OIDC_JTI WHERE JWT_ID =?";
         public static final String INSERT_JWD_ID = "INSERT INTO IDN_OIDC_JTI (JWT_ID, EXP_TIME, TIME_CREATED)" +
                 "VALUES (?,?,?)";
-        public static final String INSERT_OR_UPDATE_JWT_ID = "MERGE IDN_OIDC_JTI T USING  (VALUES (?,?,?)) " +
-                "S (JWT_ID, EXP_TIME, TIME_CREATED) ON T.JWT_ID = S.JWT_ID WHEN MATCHED THEN " +
+        public static final String INSERT_OR_UPDATE_JWT_ID_MSSQL_OR_DB2 = "MERGE IDN_OIDC_JTI T USING  " +
+                "(VALUES (?,?,?)) S (JWT_ID, EXP_TIME, TIME_CREATED) ON T.JWT_ID = S.JWT_ID WHEN MATCHED THEN " +
                 "UPDATE SET EXP_TIME = S.EXP_TIME, TIME_CREATED = S.TIME_CREATED WHEN NOT MATCHED THEN " +
                 "INSERT (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (S.JWT_ID, S.EXP_TIME,S.TIME_CREATED);";
+
+        public static final String INSERT_OR_UPDATE_JWT_ID_MYSQL = "INSERT INTO IDN_OIDC_JTI " +
+                "(JWT_ID, EXP_TIME, TIME_CREATED) VALUES (?, ?, ?)  " +
+                "ON DUPLICATE KEY UPDATE EXP_TIME = VALUES(EXP_TIME), " +
+                "TIME_CREATED = VALUES(TIME_CREATED)";
+
+        public static final String INSERT_OR_UPDATE_JWT_ID_H2 = "MERGE INTO IDN_OIDC_JTI KEY (JWT_ID) " +
+                "VALUES (?, ?, ?)";
+
+        public static final String INSERT_OR_UPDATE_JWT_ID_POSTGRESQL =
+                "INSERT INTO IDN_OIDC_JTI (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (?, ?, ?) " +
+                        "ON CONFLICT (JWT_ID) DO UPDATE SET EXP_TIME = EXCLUDED.EXP_TIME, " +
+                        "TIME_CREATED = EXCLUDED.TIME_CREATED";
+
+        public static final String INSERT_OR_UPDATE_JWT_ID_ORACLE = "MERGE INTO IDN_OIDC_JTI USING dual ON " +
+                "(JWT_ID = ?) " +
+                "WHEN MATCHED THEN UPDATE SET EXP_TIME = ? , TIME_CREATED = ? " +
+                "WHEN NOT MATCHED THEN INSERT (JWT_ID, EXP_TIME, TIME_CREATED) " +
+                " VALUES (?, ?, ?)";
 
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -47,5 +47,10 @@ public class Constants {
         public static final String GET_JWT = "SELECT EXP_TIME,TIME_CREATED FROM IDN_OIDC_JTI WHERE JWT_ID =?";
         public static final String INSERT_JWD_ID = "INSERT INTO IDN_OIDC_JTI (JWT_ID, EXP_TIME, TIME_CREATED)" +
                 "VALUES (?,?,?)";
+        public static final String INSERT_OR_UPDATE_JWT_ID = "MERGE IDN_OIDC_JTI T USING  (VALUES (?,?,?)) " +
+                "S (JWT_ID, EXP_TIME, TIME_CREATED) ON T.JWT_ID = S.JWT_ID WHEN MATCHED THEN " +
+                "UPDATE SET EXP_TIME = S.EXP_TIME, TIME_CREATED = S.TIME_CREATED WHEN NOT MATCHED THEN " +
+                "INSERT (JWT_ID, EXP_TIME, TIME_CREATED) VALUES (S.JWT_ID, S.EXP_TIME,S.TIME_CREATED);";
+
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.client.authentication.AbstractOAuthClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.validator.JWTValidator;
 
 import java.text.ParseException;
@@ -78,6 +79,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
             if (isNotEmpty(properties.getProperty(REJECT_BEFORE_IN_MINUTES))) {
                 rejectBeforePeriod = Integer.parseInt(properties.getProperty(REJECT_BEFORE_IN_MINUTES));
             }
+            JWTServiceDataHolder.getInstance().setPreventTokenReuse(preventTokenReuse);
             jwtValidator = createJWTValidator(tokenEPAlias, preventTokenReuse, rejectBeforePeriod);
         } catch (NumberFormatException e) {
             log.warn("Invalid PrivateKeyJWT Validity period found in the configuration. Using default value: " +

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -126,7 +127,11 @@ public class JWTStorageManager {
         PreparedStatement preparedStatement = null;
         try {
             connection = IdentityDatabaseUtil.getDBConnection();
-            preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_JWD_ID);
+            if (JWTServiceDataHolder.getInstance().isPreventTokenReuse()){
+                preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_JWD_ID);
+            } else {
+                preparedStatement = connection.prepareStatement(Constants.SQLQueries.INSERT_OR_UPDATE_JWT_ID);
+            }
             preparedStatement.setString(1, jti);
             Timestamp timestamp = new Timestamp(timeCreated);
             Timestamp expTimestamp = new Timestamp(expTime);

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
@@ -28,6 +28,18 @@ public class JWTServiceDataHolder {
     private RealmService realmService = null;
     public static JWTServiceDataHolder instance = new JWTServiceDataHolder();
 
+    public boolean preventTokenReuse = true;
+
+    public boolean isPreventTokenReuse() {
+
+        return preventTokenReuse;
+    }
+
+    public void setPreventTokenReuse(boolean preventTokenReuse) {
+
+        this.preventTokenReuse = preventTokenReuse;
+    }
+
     public static JWTServiceDataHolder getInstance() {
 
         return instance;

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
@@ -18,27 +18,64 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.storage;
 
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.common.testng.WithH2Database;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.util.JdbcUtils;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTEntry;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTStorageManager;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
+import java.sql.Connection;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.closeH2Base;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.initiateH2Base;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.spyConnection;
 
-@WithH2Database(jndiName = "jdbc/WSO2CarbonDB", files = {"dbscripts/identity.sql"})
-public class JWTStorageManagerTest {
+
+@PrepareForTest({IdentityUtil.class, JdbcUtils.class, IdentityDatabaseUtil.class})
+public class JWTStorageManagerTest extends PowerMockIdentityBaseTest {
 
     private JWTStorageManager JWTStorageManager;
+    private Connection spyConnection;
+
 
     @BeforeClass
     public void setUp() throws Exception {
 
+        initiateH2Base();
         JWTStorageManager = new JWTStorageManager();
+
+    }
+
+    @BeforeMethod
+    public void init() throws Exception {
+
+        mockStatic(IdentityDatabaseUtil.class);
+        spyConnection = spyConnection(JWTTestUtil.getConnection());
+        Mockito.when(IdentityDatabaseUtil.getDBConnection()).thenReturn(spyConnection);
+        mockStatic(JdbcUtils.class);
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+
+        closeH2Base();
     }
 
     @Test()
@@ -59,7 +96,7 @@ public class JWTStorageManagerTest {
         assertNotNull(JWTStorageManager.getJwtFromDB("2000"));
     }
 
-    @Test
+    @Test()
     public void testGetJwtFromDBWithNull() throws Exception {
 
         assertNull(JWTStorageManager.getJwtFromDB(null));
@@ -72,15 +109,31 @@ public class JWTStorageManagerTest {
     }
 
     @Test(expectedExceptions = OAuthClientAuthnException.class)
-    public void testPersistJWTIdInDBWithTokenReuse() throws Exception {
-
-        JWTServiceDataHolder.getInstance().setPreventTokenReuse(false);
-        JWTStorageManager.persistJWTIdInDB("2023", 10000000, 10000000);
-    }
-
-    @Test(expectedExceptions = OAuthClientAuthnException.class)
     public void testPersistJWTIdInDBExceptionCase() throws Exception {
 
         JWTStorageManager.persistJWTIdInDB("2000", 10000000, 10000000);
+    }
+
+    @Test()
+    public void testPersistJWTIdInDBWithoutTokenReuse() throws Exception {
+
+        JWTServiceDataHolder.getInstance().setPreventTokenReuse(false);
+        when(JdbcUtils.isH2DB()).thenReturn(true);
+        when(JdbcUtils.isOracleDB()).thenReturn(false);
+        // Insert a JTI entry with Expired Date.
+        JWTStorageManager.persistJWTIdInDB("2023", 10000000, 10000000);
+        when(JdbcUtils.isH2DB()).thenReturn(true);
+        when(JdbcUtils.isOracleDB()).thenReturn(false);
+        // Update a JTI entry again.
+        JWTStorageManager.persistJWTIdInDB("2023", 10001000, 10000100);
+    }
+
+    @Test(dependsOnMethods = {"testPersistJWTIdInDBWithoutTokenReuse"})
+    public void testUpdatedJTIEntry() throws Exception {
+
+        JWTServiceDataHolder.getInstance().setPreventTokenReuse(false);
+        JWTEntry jwtEntry = JWTStorageManager.getJwtFromDB("2023");
+        assertEquals(jwtEntry.getExp(), 10001000);
+        assertEquals(jwtEntry.getCreatedTime(), 10000100);
     }
 }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
@@ -21,11 +21,13 @@ package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.storage;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTStorageManager;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 @WithH2Database(jndiName = "jdbc/WSO2CarbonDB", files = {"dbscripts/identity.sql"})
@@ -46,15 +48,34 @@ public class JWTStorageManagerTest {
     }
 
     @Test()
+    public void testIsJTINotExistsInDB() throws Exception {
+
+        assertFalse(JWTStorageManager.isJTIExistsInDB("2023"));
+    }
+
+    @Test()
     public void testGetJwtFromDB() throws Exception {
 
         assertNotNull(JWTStorageManager.getJwtFromDB("2000"));
+    }
+
+    @Test
+    public void testGetJwtFromDBWithNull() throws Exception {
+
+        assertNull(JWTStorageManager.getJwtFromDB(null));
     }
 
     @Test()
     public void testPersistJWTIdInDB() throws Exception {
 
         JWTStorageManager.persistJWTIdInDB("2004", 10000000, 10000000);
+    }
+
+    @Test(expectedExceptions = OAuthClientAuthnException.class)
+    public void testPersistJWTIdInDBWithTokenReuse() throws Exception {
+
+        JWTServiceDataHolder.getInstance().setPreventTokenReuse(false);
+        JWTStorageManager.persistJWTIdInDB("2023", 10000000, 10000000);
     }
 
     @Test(expectedExceptions = OAuthClientAuthnException.class)


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/15415

Fix:
Rather than having only Insert query,
if `PreventTokenReuse==false`
then we are using Update if exists query to support the behavior

I used a data holder to store and populate the `PreventTokenReuse configuration component-wise.
Wrote queries for Multiple DBs
Tested DBs 

- [x] MSSQL
- [x] DB2
- [x] MsSQL
- [x] PostgreSQL
- [x] H2
- [x] Oracle