### PR TITLE
[Improvement] Core Service for Store config in Configuration Service.

### DIFF
--- a/component/client-handler/pom.xml
+++ b/component/client-handler/pom.xml
@@ -128,6 +128,10 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -64,11 +64,18 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
     private static final Log log = LogFactory.getLog(PrivateKeyJWTClientAuthenticator.class);
     private JWTValidator jwtValidator;
 
+    private int rejectBeforePeriod = DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
+    private boolean preventTokenReuse = true;
+    private String tokenEPAlias = DEFAULT_AUDIENCE;
+
     public PrivateKeyJWTClientAuthenticator() {
 
-        int rejectBeforePeriod = DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
-        boolean preventTokenReuse = true;
-        String tokenEPAlias = DEFAULT_AUDIENCE;
+        readServerConfig();
+        jwtValidator = createJWTValidator(tokenEPAlias, preventTokenReuse, rejectBeforePeriod);
+    }
+
+    private void readServerConfig(){
+
         try {
             if (isNotEmpty(properties.getProperty(TOKEN_ENDPOINT_ALIAS))) {
                 tokenEPAlias = properties.getProperty(TOKEN_ENDPOINT_ALIAS);
@@ -80,7 +87,6 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
                 rejectBeforePeriod = Integer.parseInt(properties.getProperty(REJECT_BEFORE_IN_MINUTES));
             }
             JWTServiceDataHolder.getInstance().setPreventTokenReuse(preventTokenReuse);
-            jwtValidator = createJWTValidator(tokenEPAlias, preventTokenReuse, rejectBeforePeriod);
         } catch (NumberFormatException e) {
             log.warn("Invalid PrivateKeyJWT Validity period found in the configuration. Using default value: " +
                     rejectBeforePeriod);

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtService.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core;
+
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+/**
+ * Service for managing the JWT Authenticator configurations of a tenant.
+ */
+public interface JWTClientAuthenticatorMgtService {
+
+    /**
+     * Get the JWT Authenticator configurations of a tenant.
+     *
+     * @param tenantDomain The tenant domain.
+     * @return JWTClientAuthenticatorConfig Returns an instance of {@code JWTClientAuthenticatorConfig} belonging to the tenant.
+     * @throws JWTClientAuthenticatorServiceException
+     */
+    JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticatorConfiguration(String tenantDomain)
+            throws JWTClientAuthenticatorServiceException;
+
+    /**
+     * Set the JWT Authenticator configurations of a tenant.
+     *
+     * @param jwtClientAuthenticatorConfig The {@code JWTClientAuthenticatorConfig} object to be set.
+     * @param tenantDomain                 The tenant domain.
+     * @throws JWTClientAuthenticatorServiceException
+     */
+    void setPrivateKeyJWTClientAuthenticatorConfiguration(
+            JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig, String tenantDomain)
+            throws JWTClientAuthenticatorServiceException;
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceImpl.java
@@ -37,8 +37,8 @@ public class JWTClientAuthenticatorMgtServiceImpl implements JWTClientAuthentica
      * {@inheritDoc}
      */
     @Override
-    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticatorConfiguration
-    (String tenantDomain) throws JWTClientAuthenticatorServiceException {
+    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticatorConfiguration (String tenantDomain)
+            throws JWTClientAuthenticatorServiceException {
 
         validateTenantDomain(tenantDomain);
 
@@ -53,8 +53,8 @@ public class JWTClientAuthenticatorMgtServiceImpl implements JWTClientAuthentica
      * {@inheritDoc}
      */
     @Override
-    public void setPrivateKeyJWTClientAuthenticatorConfiguration
-    (JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig, String tenantDomain)
+    public void setPrivateKeyJWTClientAuthenticatorConfiguration (
+            JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig, String tenantDomain)
             throws JWTClientAuthenticatorServiceException {
 
         validateTenantDomain(tenantDomain);
@@ -77,7 +77,7 @@ public class JWTClientAuthenticatorMgtServiceImpl implements JWTClientAuthentica
         try {
             IdentityTenantUtil.getTenantId(tenantDomain);
         } catch (IdentityRuntimeException e) {
-            throw handleClientException(ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN, tenantDomain);
+            throw handleClientException(ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN, e, tenantDomain);
         }
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core;
+
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.ErrorMessage;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceClientException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util.ErrorUtils.handleClientException;
+
+/**
+ * Implementation of Service for managing the JWT Authenticator configurations of a tenant.
+ */
+public class JWTClientAuthenticatorMgtServiceImpl implements JWTClientAuthenticatorMgtService {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticatorConfiguration
+    (String tenantDomain) throws JWTClientAuthenticatorServiceException {
+
+        validateTenantDomain(tenantDomain);
+
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig
+                = JWTServiceDataHolder.getInstance()
+                .getPrivateKeyJWTAuthenticationConfigurationDAO()
+                .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(tenantDomain);
+        return JWTClientAuthenticatorConfig;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPrivateKeyJWTClientAuthenticatorConfiguration
+    (JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig, String tenantDomain)
+            throws JWTClientAuthenticatorServiceException {
+
+        validateTenantDomain(tenantDomain);
+        JWTServiceDataHolder.getInstance().getPrivateKeyJWTAuthenticationConfigurationDAO()
+                .setPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain
+                        (JWTClientAuthenticatorConfig, tenantDomain);
+
+
+    }
+
+    /**
+     * Validate the tenant domain.
+     *
+     * @param tenantDomain The tenant domain.
+     * @throws JWTClientAuthenticatorServiceClientException
+     */
+    private void validateTenantDomain(String tenantDomain)
+            throws JWTClientAuthenticatorServiceClientException {
+
+        try {
+            IdentityTenantUtil.getTenantId(tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            throw handleClientException(ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN, tenantDomain);
+        }
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/Constants.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant;
+
+/**
+ * Constants listed here for the Core Component.
+ */
+public class Constants {
+
+    public static final String ENABLE_TOKEN_REUSE = "EnableTokenReuse";
+
+    /**
+     * Name of the {@code  JWTClientAuthenticatorConfig} resource type in the Configuration Management API.
+     */
+    public static final String JWT_CONFIGURATION_RESOURCE_TYPE_NAME = "PK_JWT_CONFIGURATION";
+
+    /**
+     * Name of the {@code JWTClientAuthenticatorConfig} resource (per tenant) in the Configuration Management API.
+     */
+    public static final String JWT_CONFIGURATION_RESOURCE_NAME = "TENANT_PK_JWT_CONFIGURATION";
+
+    /**
+     * Description of the {@code JWTClientAuthenticatorConfig} resource type in the Configuration Management API.
+     */
+    public static final String JWT_CONFIGURATION_RESOURCE_TYPE_DESCRIPTION =
+            "A resource type to keep the tenant private key jwt configuration.";
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessage.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessage.java
@@ -92,7 +92,5 @@ public enum ErrorMessage {
 
         return code + ":" + message;
     }
-
-
 }
 

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessage.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessage.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant;
+
+public enum ErrorMessage {
+
+    /**
+     * Invalid tenant domain.
+     */
+    ERROR_CODE_INVALID_TENANT_DOMAIN("60004",
+            "Invalid input.",
+            "%s is not a valid tenant domain."),
+
+    /**
+     * Unable to retrieve JWT Authenticator configuration.
+     */
+    ERROR_CODE_PK_JWT_CONFIG_RETRIEVE("65007",
+            "Unable to retrieve JWT Authenticator configuration.",
+            "Server encountered an error while retrieving the " +
+                    "JWT Authenticator configuration of %s.");
+
+    /**
+     * The error code.
+     */
+    private final String code;
+
+    /**
+     * The error message.
+     */
+    private final String message;
+
+    /**
+     * The error description.
+     */
+    private final String description;
+
+
+    ErrorMessage(String code, String message, String description) {
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    /**
+     * Get the {@code code}.
+     *
+     * @return Returns the {@code code} to be set.
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Get the {@code message}.
+     *
+     * @return Returns the {@code message} to be set.
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Get the {@code description}.
+     *
+     * @return Returns the {@code description} to be set.
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    @Override
+    public String toString() {
+
+        return code + ":" + message;
+    }
+
+
+}
+

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/JWTAuthenticationConfigurationDAO.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/JWTAuthenticationConfigurationDAO.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao;
+
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+/**
+ * Perform CRUD operations for {@link JWTClientAuthenticatorConfig}.
+ */
+public interface JWTAuthenticationConfigurationDAO {
+
+    /**
+     * Get priority value for the {@link JWTAuthenticationConfigurationDAO}.
+     *
+     * @return Priority value for the DAO.
+     */
+    int getPriority();
+
+    /**
+     * Get the JWT Authenticator configuration of a tenant.
+     *
+     * @param tenantDomain The tenant domain.
+     * @return JWTClientAuthenticatorConfig The configuration model.
+     * @throws JWTClientAuthenticatorServiceServerException JWTClientAuthenticatorServiceServerException
+     */
+    JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(String tenantDomain)
+            throws JWTClientAuthenticatorServiceServerException;
+
+    /**
+     * Set the JWT Authenticator configuration of a tenant.
+     *
+     * @param JWTClientAuthenticatorConfig The new JWT Authenticator configuration to be set.
+     * @param tenantDomain                 The tenant domain.
+     * @throws JWTClientAuthenticatorServiceServerException JWTClientAuthenticatorServiceServerException
+     */
+    void setPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig, String tenantDomain)
+            throws JWTClientAuthenticatorServiceServerException;
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCache.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache;
+
+import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationBaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Implements a cache to store JWT Configurations.
+ */
+public class JWTConfigCache extends AuthenticationBaseCache<JWTConfigCacheKey, JWTConfigCacheEntry> {
+    public static final String PRIVATE_KEY_JWT_CONFIG_CACHE = "PrivateKeyJWTConfig";
+    private static volatile JWTConfigCache instance;
+
+    private JWTConfigCache() {
+        super(PRIVATE_KEY_JWT_CONFIG_CACHE);
+    }
+
+    public static JWTConfigCache getInstance() {
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (JWTConfigCache.class) {
+                if (instance == null) {
+                    instance = new JWTConfigCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheEntry.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheEntry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+/**
+ * Cache Entry for JWT Configuration Cache.
+ */
+public class JWTConfigCacheEntry extends CacheEntry {
+    private JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig;
+
+    public JWTConfigCacheEntry(JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig) {
+
+        this.JWTClientAuthenticatorConfig = JWTClientAuthenticatorConfig;
+    }
+
+    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticatorConfig() {
+
+        return JWTClientAuthenticatorConfig;
+    }
+
+    public void setPrivateKeyJWTClientAuthenticatorConfig(
+            JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig) {
+
+        this.JWTClientAuthenticatorConfig = JWTClientAuthenticatorConfig;
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheKey.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheKey.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheKey;
+
+/**
+ * Cache key used to access JWT Configuration Cache Entry.
+ */
+public class JWTConfigCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 718492345264523421L;
+
+    private final String tenantDomain;
+
+    public String getTenantDomain() {
+
+        return tenantDomain;
+    }
+
+    public JWTConfigCacheKey(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+    }
+
+    /**
+     * Equals method to compare two JWT Cache Key.
+     *
+     * @param o java.lang.Object
+     * @return True if both objects are same.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        JWTConfigCacheKey that = (JWTConfigCacheKey) o;
+
+        return tenantDomain.equals(that.getTenantDomain());
+    }
+
+
+    /**
+     * This method used to derive hash value for this class.
+     * Idea of this hash method is return same value for same object and return different value for different object.
+     * Number 31 is used as common prime number to multiply result to get unique hash value.
+     *
+     * @return Hashcode.
+     */
+    @Override
+    public int hashCode() {
+
+        int result = super.hashCode();
+        result = 31 * result + tenantDomain.hashCode();
+        return result;
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheKey.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheKey.java
@@ -58,10 +58,8 @@ public class JWTConfigCacheKey extends CacheKey {
         }
 
         JWTConfigCacheKey that = (JWTConfigCacheKey) o;
-
         return tenantDomain.equals(that.getTenantDomain());
     }
-
 
     /**
      * This method used to derive hash value for this class.

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/CacheBackedJWTConfigurationDAOImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/CacheBackedJWTConfigurationDAOImpl.java
@@ -62,6 +62,10 @@ public class CacheBackedJWTConfigurationDAOImpl implements JWTAuthenticationConf
 
         JWTClientAuthenticatorConfig cachedResult = getJWTConfigurationFromCache(tenantDomain);
         if (cachedResult != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("JWT Authenticator configuration is not available " +
+                        "in the cache for tenant domain: " + tenantDomain + ". Trying to get data from the database.");
+            }
             return cachedResult;
         }
 

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/CacheBackedJWTConfigurationDAOImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/CacheBackedJWTConfigurationDAOImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.JWTAuthenticationConfigurationDAO;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCache;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCacheEntry;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCacheKey;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+/**
+ * Cached DAO layer for JWT Authenticator Configurations.
+ * All the DAO access should happen through this layer to ensure single point of caching.
+ */
+public class CacheBackedJWTConfigurationDAOImpl implements JWTAuthenticationConfigurationDAO {
+
+    private static final Log log = LogFactory.getLog(CacheBackedJWTConfigurationDAOImpl.class);
+
+    private final JWTAuthenticationConfigurationDAO privateKeyJWTAuthenticationConfigurationDAO;
+
+    public CacheBackedJWTConfigurationDAOImpl(JWTAuthenticationConfigurationDAO
+                                                      privateKeyJWTAuthenticationConfigurationDAO) {
+
+        this.privateKeyJWTAuthenticationConfigurationDAO = privateKeyJWTAuthenticationConfigurationDAO;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority() {
+
+        return 5;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(
+            String tenantDomain)
+            throws JWTClientAuthenticatorServiceServerException {
+
+        JWTClientAuthenticatorConfig cachedResult = getJWTConfigurationFromCache(tenantDomain);
+        if (cachedResult != null) {
+            return cachedResult;
+        }
+
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig = privateKeyJWTAuthenticationConfigurationDAO.
+                getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(tenantDomain);
+
+        addJWTAuthenticatorConfigurationToCache(JWTClientAuthenticatorConfig, tenantDomain);
+        return JWTClientAuthenticatorConfig;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(
+            JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig, String tenantDomain)
+            throws JWTClientAuthenticatorServiceServerException {
+
+        clearCaches(tenantDomain);
+        privateKeyJWTAuthenticationConfigurationDAO.setPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain
+                (JWTClientAuthenticatorConfig, tenantDomain);
+    }
+
+    /**
+     * Add JWT Authenticator configurations to the cache.
+     *
+     * @param JWTClientAuthenticatorConfig The JWT Authenticator configuration that should be added to the cache.
+     * @param tenantDomain                 The tenant domain specific to the cache entry.
+     */
+    private void addJWTAuthenticatorConfigurationToCache(
+            JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig,
+            String tenantDomain) {
+
+        JWTConfigCacheKey cacheKey = new JWTConfigCacheKey(tenantDomain);
+        JWTConfigCacheEntry cacheEntry = new JWTConfigCacheEntry(JWTClientAuthenticatorConfig);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Adding JWT Authenticator configuration to Cache with Key: " + tenantDomain);
+        }
+
+        JWTConfigCache.getInstance().addToCache(cacheKey, cacheEntry, tenantDomain);
+    }
+
+    /**
+     * Get JWT Authenticator configuration from the cache.
+     *
+     * @param tenantDomain The tenant domain specific to the cache entry.
+     * @return Returns an instance of {@code JWTClientAuthenticatorConfig}(s)
+     * if the cached JWT Authenticator configuration is found for the tenant. Else return {@code null}.
+     */
+    private JWTClientAuthenticatorConfig getJWTConfigurationFromCache(String tenantDomain) {
+
+        JWTConfigCacheKey cacheKey = new JWTConfigCacheKey(tenantDomain);
+        JWTConfigCache cache = JWTConfigCache.getInstance();
+        JWTConfigCacheEntry cacheEntry = cache.getValueFromCache(cacheKey, tenantDomain);
+
+        if (cacheEntry != null && cacheEntry.getPrivateKeyJWTClientAuthenticatorConfig() != null) {
+            return cacheEntry.getPrivateKeyJWTClientAuthenticatorConfig();
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache entry not found for cache key :" + tenantDomain);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Clear JWT Authenticator configuration caches of a particular tenant.
+     *
+     * @param tenantDomain The domain of the tenant.
+     */
+    private void clearCaches(String tenantDomain) {
+
+        JWTConfigCacheKey cacheKey = new JWTConfigCacheKey(tenantDomain);
+        JWTConfigCache.getInstance().clearCacheEntry(cacheKey, tenantDomain);
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/JWTAuthenticationConfigurationDAOImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/JWTAuthenticationConfigurationDAOImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl;
+
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.JWTAuthenticationConfigurationDAO;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util.Util;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.JWT_CONFIGURATION_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.JWT_CONFIGURATION_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.ErrorMessage.ERROR_CODE_PK_JWT_CONFIG_RETRIEVE;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util.ErrorUtils.handleServerException;
+
+/**
+ * DAO layer for JWT Authenticator Configurations.
+ */
+public class JWTAuthenticationConfigurationDAOImpl implements JWTAuthenticationConfigurationDAO {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority() {
+        return 10;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JWTClientAuthenticatorConfig getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain
+    (String tenantDomain) throws JWTClientAuthenticatorServiceServerException {
+
+        try {
+
+            Resource resource = getResource(JWT_CONFIGURATION_RESOURCE_TYPE_NAME, JWT_CONFIGURATION_RESOURCE_NAME);
+            JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig;
+            if (resource == null) {
+                JWTClientAuthenticatorConfig = Util.getServerConfiguration();
+            } else {
+                JWTClientAuthenticatorConfig = Util.parseResource(resource);
+            }
+            return JWTClientAuthenticatorConfig;
+        } catch (ConfigurationManagementException e) {
+            throw handleServerException(ERROR_CODE_PK_JWT_CONFIG_RETRIEVE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain
+    (JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig, String tenantDomain)
+            throws JWTClientAuthenticatorServiceServerException {
+
+        try {
+            ResourceAdd resourceAdd = Util.parseConfig(jwtClientAuthenticatorConfig);
+            getConfigurationManager().replaceResource(JWT_CONFIGURATION_RESOURCE_TYPE_NAME, resourceAdd);
+        } catch (ConfigurationManagementException e) {
+            throw handleServerException(ERROR_CODE_PK_JWT_CONFIG_RETRIEVE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Retrieve the ConfigurationManager instance from the JWTServiceDataHolder.
+     *
+     * @return ConfigurationManager The ConfigurationManager instance.
+     */
+    private ConfigurationManager getConfigurationManager() {
+
+        return JWTServiceDataHolder.getInstance().getConfigurationManager();
+    }
+
+    /**
+     * Configuration Management API returns a ConfigurationManagementException with the error code CONFIGM_00017 when
+     * resource is not found. This method wraps the original method and returns null if the resource is not found.
+     *
+     * @param resourceTypeName Resource type name.
+     * @param resourceName     Resource name.
+     * @return Retrieved resource from the configuration store. Returns {@code null} if the resource is not found.
+     * @throws ConfigurationManagementException
+     */
+    private Resource getResource(String resourceTypeName, String resourceName) throws ConfigurationManagementException {
+
+        try {
+            return getConfigurationManager().getResource(resourceTypeName, resourceName);
+        } catch (ConfigurationManagementException e) {
+            if (e.getErrorCode().equals(ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode())) {
+                return null;
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/JWTAuthenticationConfigurationDAOImpl.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/impl/JWTAuthenticationConfigurationDAOImpl.java
@@ -109,7 +109,7 @@ public class JWTAuthenticationConfigurationDAOImpl implements JWTAuthenticationC
         try {
             return getConfigurationManager().getResource(resourceTypeName, resourceName);
         } catch (ConfigurationManagementException e) {
-            if (e.getErrorCode().equals(ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode())) {
+            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
                 return null;
             } else {
                 throw e;

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceClientException.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceClientException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception;
+
+/**
+ * Client exception class for the JWT Authentication Service.
+ */
+public class JWTClientAuthenticatorServiceClientException extends JWTClientAuthenticatorServiceException {
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorServiceClientException() {
+
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorServiceClientException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceClientException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceClientException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceException.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceException.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception;
+
+/**
+ * Base exception class for the JWT Authentication Service.
+ */
+public class JWTClientAuthenticatorServiceException extends Exception {
+
+    /**
+     * The error code.
+     */
+    private String errorCode;
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorServiceException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorServiceException(String message, String errorCode) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceException(String message, String errorCode, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceException(Throwable cause) {
+
+        super(cause);
+    }
+
+    /**
+     * Get the {@code errorCode}.
+     *
+     * @return Returns the {@code errorCode}.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    /**
+     * Set the {@code errorCode}.
+     *
+     * @param errorCode The value to be set as the {@code errorCode}.
+     */
+    protected void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceServerException.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/exception/JWTClientAuthenticatorServiceServerException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception;
+
+/**
+ * Server exception class for the JWT Authenticator Service.
+ */
+public class JWTClientAuthenticatorServiceServerException extends JWTClientAuthenticatorServiceException {
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorServiceServerException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorServiceServerException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceServerException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServiceServerException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/model/JWTClientAuthenticatorConfig.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/model/JWTClientAuthenticatorConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model;
+
+/**
+ * JWT Client Authenticator Configuration Model class for DAOs.
+ */
+public class JWTClientAuthenticatorConfig {
+
+    /**
+     * If {@code true} JTI for JWT can be reused only if previous JWT expires,
+     * else JTI is unique even after the expiration.
+     */
+    private boolean enableTokenReuse;
+
+    public boolean isEnableTokenReuse() {
+
+        return enableTokenReuse;
+    }
+
+    public void setEnableTokenReuse(boolean enableTokenReuse) {
+
+        this.enableTokenReuse = enableTokenReuse;
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/ErrorUtils.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/ErrorUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util;
+
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.ErrorMessage;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceClientException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
+
+/**
+ * Error utilities.
+ */
+public class ErrorUtils {
+
+    /**
+     * Handle server exceptions.
+     *
+     * @param error The ErrorMessage.
+     * @param data  Additional data that should be added to the error message. This is a String var-arg.
+     * @return JWTClientAuthenticatorServiceServerException instance.
+     */
+    public static JWTClientAuthenticatorServiceServerException handleServerException(ErrorMessage error,
+                                                                                     String... data) {
+
+        return new JWTClientAuthenticatorServiceServerException
+                (String.format(error.getDescription(), data), error.getCode());
+    }
+
+    /**
+     * Handle server exceptions.
+     *
+     * @param error The ErrorMessage.
+     * @param e     Original error.
+     * @param data  Additional data that should be added to the error message. This is a String var-arg.
+     * @return JWTClientAuthenticatorServiceServerException instance.
+     */
+    public static JWTClientAuthenticatorServiceServerException handleServerException(ErrorMessage error,
+                                                                                     Throwable e,
+                                                                                     String... data) {
+
+        return new JWTClientAuthenticatorServiceServerException
+                (String.format(error.getDescription(), data), error.getCode(),
+                        e);
+    }
+
+    /**
+     * Handle client exceptions.
+     *
+     * @param error The ErrorMessage.
+     * @param data  Additional data that should be added to the error message. This is a String var-arg.
+     * @return JWTClientAuthenticatorServiceClientException instance.
+     */
+    public static JWTClientAuthenticatorServiceClientException handleClientException(ErrorMessage error,
+                                                                                     String... data) {
+
+        return new JWTClientAuthenticatorServiceClientException(String.format(error.getDescription(), data),
+                error.getCode());
+    }
+
+    /**
+     * Handle client exceptions.
+     *
+     * @param error The ErrorMessage.
+     * @param e     Original error.
+     * @param data  Additional data that should be added to the error message. This is a String var-arg.
+     * @return JWTClientAuthenticatorServiceClientException instance.
+     */
+    public static JWTClientAuthenticatorServiceClientException handleClientException(ErrorMessage error,
+                                                                                     Throwable e,
+                                                                                     String... data) {
+
+        return new JWTClientAuthenticatorServiceClientException(String.format(error.getDescription(), data),
+                error.getCode(),
+                e);
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.ENABLE_TOKEN_REUSE;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.JWT_CONFIGURATION_RESOURCE_NAME;
+
+/**
+ * Util class.
+ */
+public class Util {
+
+    /**
+     * Read the default JWT Authenticator configuration properties from the Data Holder..
+     *
+     * @return Server default {@code JWTClientAuthenticatorConfig} object.
+     */
+    public static JWTClientAuthenticatorConfig getServerConfiguration() {
+
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig
+                = new JWTClientAuthenticatorConfig();
+
+        JWTClientAuthenticatorConfig.
+                setEnableTokenReuse(JWTServiceDataHolder.getInstance().isPreventTokenReuse());
+        return JWTClientAuthenticatorConfig;
+    }
+
+    /**
+     * Parse Resource to JWTClientAuthenticatorConfig instance.
+     *
+     * @param resource Resource
+     * @return JWTClientAuthenticatorConfig Configuration instance.
+     */
+    public static JWTClientAuthenticatorConfig parseResource(Resource resource) {
+
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig
+                = new JWTClientAuthenticatorConfig();
+
+        if (resource.isHasAttribute()) {
+            List<Attribute> attributes = resource.getAttributes();
+            Map<String, String> attributeMap = getAttributeMap(attributes);
+            JWTClientAuthenticatorConfig.setEnableTokenReuse(
+                    Boolean.parseBoolean(attributeMap.get(ENABLE_TOKEN_REUSE)));
+        }
+        return JWTClientAuthenticatorConfig;
+
+    }
+
+    private static Map<String, String> getAttributeMap(List<Attribute> attributes) {
+
+        if (attributes != null) {
+            return attributes.stream().collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
+        }
+
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Parse JWTClientAuthenticatorConfig to Resource instance.
+     *
+     * @param JWTClientAuthenticatorConfig Configuration Instance.
+     * @return ResourceAdd Resource instance.
+     */
+    public static ResourceAdd parseConfig(JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig) {
+
+        ResourceAdd resourceAdd = new ResourceAdd();
+        resourceAdd.setName(JWT_CONFIGURATION_RESOURCE_NAME);
+        List<Attribute> attributes = new ArrayList<>();
+        addAttribute(attributes, ENABLE_TOKEN_REUSE,
+                String.valueOf(JWTClientAuthenticatorConfig.isEnableTokenReuse()));
+        resourceAdd.setAttributes(attributes);
+        return resourceAdd;
+    }
+
+    private static void addAttribute(List<Attribute> attributeList, String key, String value) {
+
+        if (StringUtils.isNotBlank(value)) {
+            Attribute attribute = new Attribute();
+            attribute.setKey(key);
+            attribute.setValue(value);
+            attributeList.add(attribute);
+        }
+    }
+}

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
@@ -46,8 +47,7 @@ public class Util {
      */
     public static JWTClientAuthenticatorConfig getServerConfiguration() {
 
-        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig
-                = new JWTClientAuthenticatorConfig();
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
 
         JWTClientAuthenticatorConfig.
                 setEnableTokenReuse(JWTServiceDataHolder.getInstance().isPreventTokenReuse());
@@ -62,8 +62,7 @@ public class Util {
      */
     public static JWTClientAuthenticatorConfig parseResource(Resource resource) {
 
-        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig
-                = new JWTClientAuthenticatorConfig();
+        JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
 
         if (resource.isHasAttribute()) {
             List<Attribute> attributes = resource.getAttributes();
@@ -77,7 +76,7 @@ public class Util {
 
     private static Map<String, String> getAttributeMap(List<Attribute> attributes) {
 
-        if (attributes != null) {
+        if (CollectionUtils.isNotEmpty(attributes)) {
             return attributes.stream().collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
         }
 
@@ -87,25 +86,26 @@ public class Util {
     /**
      * Parse JWTClientAuthenticatorConfig to Resource instance.
      *
-     * @param JWTClientAuthenticatorConfig Configuration Instance.
+     * @param jwtClientAuthenticatorConfig Configuration Instance.
      * @return ResourceAdd Resource instance.
      */
-    public static ResourceAdd parseConfig(JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig) {
+    public static ResourceAdd parseConfig(JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig) {
 
         ResourceAdd resourceAdd = new ResourceAdd();
         resourceAdd.setName(JWT_CONFIGURATION_RESOURCE_NAME);
         List<Attribute> attributes = new ArrayList<>();
-        addAttribute(attributes, ENABLE_TOKEN_REUSE,
-                String.valueOf(JWTClientAuthenticatorConfig.isEnableTokenReuse()));
+        addAttribute(attributes, jwtClientAuthenticatorConfig);
         resourceAdd.setAttributes(attributes);
         return resourceAdd;
     }
 
-    private static void addAttribute(List<Attribute> attributeList, String key, String value) {
+    private static void addAttribute(List<Attribute> attributeList,
+                                     JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig) {
 
+        String value = String.valueOf(jwtClientAuthenticatorConfig.isEnableTokenReuse());
         if (StringUtils.isNotBlank(value)) {
             Attribute attribute = new Attribute();
-            attribute.setKey(key);
+            attribute.setKey(ENABLE_TOKEN_REUSE);
             attribute.setValue(value);
             attributeList.add(attribute);
         }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceComponent.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceComponent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,9 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License
+ * under the License.
  */
+
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal;
 
 import org.apache.commons.logging.Log;
@@ -26,9 +27,12 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.PrivateKeyJWTClientAuthenticator;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtService;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.Util;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -73,6 +77,8 @@ public class JWTServiceComponent {
             bundleContext = ctxt.getBundleContext();
             bundleContext.registerService(OAuthClientAuthenticator.class.getName(), privateKeyJWTClientAuthenticator,
                     null);
+            bundleContext.registerService(JWTClientAuthenticatorMgtService.class.getName(),
+                    new JWTClientAuthenticatorMgtServiceImpl(), null);
             if (log.isDebugEnabled()) {
                 log.debug("Private Key JWT client handler is activated");
             }
@@ -117,5 +123,39 @@ public class JWTServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("Set Identity core Intialized Event Service.");
         }
+    }
+
+    /**
+     * Set the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigurationManager"
+    )
+    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Registering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        JWTServiceDataHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+
+    /**
+     * Unset the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unregistering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        JWTServiceDataHolder.getInstance().setConfigurationManager(null);
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/internal/JWTServiceDataHolder.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal;
 
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.JWTAuthenticationConfigurationDAO;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl.CacheBackedJWTConfigurationDAOImpl;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl.JWTAuthenticationConfigurationDAOImpl;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -29,6 +33,20 @@ public class JWTServiceDataHolder {
     public static JWTServiceDataHolder instance = new JWTServiceDataHolder();
 
     public boolean preventTokenReuse = true;
+    private ConfigurationManager configurationManager;
+
+    private JWTAuthenticationConfigurationDAO JWTAuthenticationConfigurationDAO =
+            new CacheBackedJWTConfigurationDAOImpl(new JWTAuthenticationConfigurationDAOImpl());
+
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
+    }
 
     public boolean isPreventTokenReuse() {
 
@@ -53,6 +71,17 @@ public class JWTServiceDataHolder {
     public void setRealmService(RealmService realmService) {
 
         this.realmService = realmService;
+    }
+
+    public JWTAuthenticationConfigurationDAO getPrivateKeyJWTAuthenticationConfigurationDAO() {
+
+        return JWTAuthenticationConfigurationDAO;
+    }
+
+    public void setJWTAuthenticationConfigurationDAO
+            (JWTAuthenticationConfigurationDAO JWTAuthenticationConfigurationDAO) {
+
+        this.JWTAuthenticationConfigurationDAO = JWTAuthenticationConfigurationDAO;
     }
 
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -46,9 +46,11 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCache;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCacheEntry;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCacheKey;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTEntry;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTStorageManager;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.Util;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidator;
@@ -162,6 +164,10 @@ public class JWTValidator {
                 issuedTime = issuedAtTime.getTime();
             }
 
+            preventTokenReuse = JWTServiceDataHolder.getInstance()
+                    .getPrivateKeyJWTAuthenticationConfigurationDAO()
+                    .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(tenantDomain).isEnableTokenReuse();
+
             //Validate signature validation, audience, nbf,exp time, jti.
             if (!validateAudience(validAud, audience)
                     || !validateJWTWithExpTime(expirationTime, currentTimeInMillis, timeStampSkewMillis)
@@ -175,7 +181,7 @@ public class JWTValidator {
 
             return true;
 
-        } catch (IdentityOAuth2Exception | UserStoreException e) {
+        } catch (IdentityOAuth2Exception | UserStoreException | JWTClientAuthenticatorServiceServerException e) {
             return logAndThrowException(e.getMessage());
         }
     }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core;
+
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithKeyStore;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCache;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCacheEntry;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCacheKey;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl.CacheBackedJWTConfigurationDAOImpl;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.impl.JWTAuthenticationConfigurationDAOImpl;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+@WithCarbonHome
+@WithKeyStore
+public class JWTClientAuthenticatorMgtServiceTest {
+
+    private JWTAuthenticationConfigurationDAOImpl jwtAuthenticationConfigurationDAO;
+
+    private CacheBackedJWTConfigurationDAOImpl cacheBackedJWTConfigurationDAO;
+
+    private ConfigurationManager mockConfigurationManager;
+
+    private JWTClientAuthenticatorMgtService jwtClientAuthenticatorMgtService;
+
+
+    @BeforeClass
+    public void setUp() throws Exception {
+
+        jwtAuthenticationConfigurationDAO = new JWTAuthenticationConfigurationDAOImpl();
+        cacheBackedJWTConfigurationDAO = new CacheBackedJWTConfigurationDAOImpl(jwtAuthenticationConfigurationDAO);
+        JWTServiceDataHolder.getInstance().setJWTAuthenticationConfigurationDAO(cacheBackedJWTConfigurationDAO);
+        jwtClientAuthenticatorMgtService = new JWTClientAuthenticatorMgtServiceImpl();
+        mockConfigurationManager = Mockito.mock(ConfigurationManager.class);
+        JWTServiceDataHolder.getInstance()
+                .setConfigurationManager(mockConfigurationManager);
+
+
+    }
+
+    @Test()
+    private void testGetConfig() throws Exception {
+
+        JWTConfigCacheKey jwtCacheKey = new JWTConfigCacheKey("sampleTenant");
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
+        jwtClientAuthenticatorConfig.setEnableTokenReuse(true);
+        JWTConfigCacheEntry jwtConfigCacheEntry = new JWTConfigCacheEntry(jwtClientAuthenticatorConfig);
+
+        JWTConfigCache.getInstance().addToCache(jwtCacheKey, jwtConfigCacheEntry);
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig1 = JWTServiceDataHolder
+                .getInstance().getPrivateKeyJWTAuthenticationConfigurationDAO()
+                .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain("sampleTenant");
+
+        assertNotNull(jwtClientAuthenticatorConfig1);
+        assertTrue(jwtClientAuthenticatorConfig1.isEnableTokenReuse());
+    }
+}

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
@@ -58,8 +58,6 @@ public class JWTClientAuthenticatorMgtServiceTest {
         mockConfigurationManager = Mockito.mock(ConfigurationManager.class);
         JWTServiceDataHolder.getInstance()
                 .setConfigurationManager(mockConfigurationManager);
-
-
     }
 
     @Test()

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessageTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/constant/ErrorMessageTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ErrorMessageTest {
+
+    @Test()
+    public void testErrorMessageAttributes() {
+
+        ErrorMessage errorMessage = ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN;
+        assertEquals(errorMessage.getCode(), "60004");
+        assertEquals(errorMessage.getMessage(), "Invalid input.");
+        assertEquals(errorMessage.getDescription()  , "%s is not a valid tenant domain.");
+        assertEquals(errorMessage.toString(),"60004:Invalid input.");
+    }
+}

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/dao/cache/JWTConfigCacheTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithKeyStore;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@WithCarbonHome
+@WithKeyStore
+public class JWTConfigCacheTest {
+
+    private JWTConfigCache jwtConfigCache;
+    private JWTConfigCacheKey jwtCacheKey;
+
+    private JWTConfigCacheEntry jwtConfigCacheEntry;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+
+        jwtConfigCache = JWTConfigCache.getInstance();
+        jwtCacheKey = new JWTConfigCacheKey("sampleTenant");
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
+        jwtClientAuthenticatorConfig.setEnableTokenReuse(true);
+        jwtConfigCacheEntry = new JWTConfigCacheEntry(jwtClientAuthenticatorConfig);
+    }
+
+    @Test()
+    public void testCache() throws Exception {
+
+        assertNotNull(jwtConfigCache);
+    }
+
+    @Test()
+    public void testAddToCache() throws Exception {
+        jwtConfigCache.addToCache(jwtCacheKey, jwtConfigCacheEntry);
+
+    }
+
+    @Test(dependsOnMethods = {"testAddToCache"})
+    public void testGetValueFromCache() throws Exception {
+        assertEquals(jwtConfigCache.getValueFromCache(jwtCacheKey), jwtConfigCacheEntry);
+    }
+
+    @Test(dependsOnMethods = {"testGetValueFromCache"})
+    public void testClearCacheEntry() throws Exception {
+        jwtConfigCache.clearCacheEntry(jwtCacheKey);
+        assertNull(jwtConfigCache.getValueFromCache(jwtCacheKey));
+
+    }
+}

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/UtilTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/UtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.ENABLE_TOKEN_REUSE;
+import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.JWT_CONFIGURATION_RESOURCE_NAME;
+
+public class UtilTest {
+
+    @Test()
+    public void testServerConfig() throws Exception {
+
+        JWTServiceDataHolder.getInstance().setPreventTokenReuse(true);
+        assertTrue(Util.getServerConfiguration().isEnableTokenReuse());
+    }
+
+    @Test()
+    public void testResource() throws Exception {
+
+        Resource resourceAdd = new Resource();
+        resourceAdd.setResourceName(JWT_CONFIGURATION_RESOURCE_NAME);
+        List<Attribute> attributes = new ArrayList<>();
+        addAttribute(attributes, ENABLE_TOKEN_REUSE,
+                String.valueOf(true));
+        resourceAdd.setAttributes(attributes);
+        resourceAdd.setHasAttribute(true);
+
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = Util.parseResource(resourceAdd);
+        assertNotNull(jwtClientAuthenticatorConfig);
+        assertTrue(jwtClientAuthenticatorConfig.isEnableTokenReuse());
+    }
+
+    private void addAttribute(List<Attribute> attributeList, String key, String value) {
+
+        if (StringUtils.isNotBlank(value)) {
+            Attribute attribute = new Attribute();
+            attribute.setKey(key);
+            attribute.setValue(value);
+            attributeList.add(attribute);
+        }
+    }
+
+    @Test()
+    public void testConfig() throws Exception {
+
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
+        jwtClientAuthenticatorConfig.setEnableTokenReuse(true);
+        ResourceAdd resourceAdd = Util.parseConfig(jwtClientAuthenticatorConfig);
+        assertEquals(resourceAdd.getAttributes().get(0).getKey(), ENABLE_TOKEN_REUSE);
+        assertTrue(Boolean.parseBoolean(resourceAdd.getAttributes().get(0).getValue()));
+    }
+}

--- a/component/client-handler/src/test/resources/testng.xml
+++ b/component/client-handler/src/test/resources/testng.xml
@@ -27,6 +27,12 @@
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCacheTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.PrivateKeyJWTClientAuthenticatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.storage.JWTStorageManagerTest"/>
+
+            <!--Core  Testcases-->
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.ErrorMessageTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.cache.JWTConfigCacheTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.util.UtilTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtServiceTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.version}</version>
+            </dependency>
             <!--Test Dependencies-->
             <dependency>
                 <groupId>org.testng</groupId>


### PR DESCRIPTION
## Purpose
This will add Core service to store JWT Authenticator config in the backend rather than relay on toml file configuration. This will enable tenant-wise configuration. 

This can be used to develop REST API for this configuration.

Cache layer - Store configuration in memory.
DAO layer - Store Configuration as resource in configuration management service.