### PR TITLE
[Bug fixing] Fix faulty set of prevent token reuse resource attribute

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/Util.java
@@ -50,7 +50,7 @@ public class Util {
         JWTClientAuthenticatorConfig JWTClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
 
         JWTClientAuthenticatorConfig.
-                setEnableTokenReuse(JWTServiceDataHolder.getInstance().isPreventTokenReuse());
+                setEnableTokenReuse(!JWTServiceDataHolder.getInstance().isPreventTokenReuse());
         return JWTClientAuthenticatorConfig;
     }
 

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/JWTClientAuthenticatorMgtServiceTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.imp
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -74,6 +75,6 @@ public class JWTClientAuthenticatorMgtServiceTest {
                 .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain("sampleTenant");
 
         assertNotNull(jwtClientAuthenticatorConfig1);
-        assertTrue(jwtClientAuthenticatorConfig1.isEnableTokenReuse());
+        assertFalse(jwtClientAuthenticatorConfig1.isEnableTokenReuse());
     }
 }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/UtilTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/core/util/UtilTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.constant.Constants.ENABLE_TOKEN_REUSE;
@@ -41,7 +42,7 @@ public class UtilTest {
     public void testServerConfig() throws Exception {
 
         JWTServiceDataHolder.getInstance().setPreventTokenReuse(true);
-        assertTrue(Util.getServerConfiguration().isEnableTokenReuse());
+        assertFalse(Util.getServerConfiguration().isEnableTokenReuse());
     }
 
     @Test()


### PR DESCRIPTION
## Purpose
JWTClientAuthenticatorConfig expects a property to setEnableTokenReuse, but from the server, the config we are returning isPreventTokenReuse which contrasts the prior one.

Hence we need a **!**.
