### PR TITLE
[Bug-fixing] Fix enable token reuse improper workflow

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
@@ -82,10 +82,10 @@ public class JWTStorageManager {
         boolean isExists = false;
         ResultSet rs = null;
         try {
-            if (Util.isTenantIdColumnAvailableInIdnOidcAuth()){
+            if (Util.isTenantIdColumnAvailableInIdnOidcAuth()) {
                 log.warn("Checking JWT existence with JTI only, but tenant id also required to fetch unique data." +
                         "This method will be deprecated soon. Use getJwtsFromDB instead.");
-            }else {
+            } else {
                 prepStmt = dbConnection.prepareStatement(Constants.SQLQueries.GET_JWT_ID);
                 prepStmt.setString(1, jti);
                 rs = prepStmt.executeQuery();
@@ -171,14 +171,32 @@ public class JWTStorageManager {
      * @param expTime     Expiration time.
      * @param timeCreated JTI inserted time.
      * @throws IdentityOAuth2Exception
+     * @deprecated Use {@link #persistJWTIdInDB(String, int, long, long, boolean)} instead.
      */
-    public void persistJWTIdInDB(String jti, int tenantId, long expTime, long timeCreated) throws OAuthClientAuthnException {
+    public void persistJWTIdInDB(String jti, int tenantId, long expTime, long timeCreated)
+            throws OAuthClientAuthnException {
+
+        persistJWTIdInDB(jti, tenantId, expTime, timeCreated, JWTServiceDataHolder.getInstance().isPreventTokenReuse());
+    }
+
+    /**
+     * To persist unique id for jti in the table.
+     *
+     * @param jti               JTI a unique id.
+     * @param tenantId          Tenant id.
+     * @param expTime           Expiration time.
+     * @param timeCreated       JTI inserted time.
+     * @param preventTokenReuse Whether to prevent token reuse.
+     * @throws IdentityOAuth2Exception
+     */
+    public void persistJWTIdInDB(String jti, int tenantId, long expTime, long timeCreated, boolean preventTokenReuse)
+            throws OAuthClientAuthnException {
 
         Connection connection = null;
         PreparedStatement preparedStatement = null;
         try {
             connection = IdentityDatabaseUtil.getDBConnection();
-            if (JWTServiceDataHolder.getInstance().isPreventTokenReuse()) {
+            if (preventTokenReuse) {
                 preparedStatement = connection.prepareStatement(Util.getDBQuery(INSERT_JWD_ID));
                 preparedStatement.setString(1, jti);
                 if (Util.isTenantIdColumnAvailableInIdnOidcAuth()) {

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -164,7 +164,7 @@ public class JWTValidator {
                 issuedTime = issuedAtTime.getTime();
             }
 
-            preventTokenReuse = JWTServiceDataHolder.getInstance()
+            preventTokenReuse = !JWTServiceDataHolder.getInstance()
                     .getPrivateKeyJWTAuthenticationConfigurationDAO()
                     .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(tenantDomain).isEnableTokenReuse();
 
@@ -343,7 +343,7 @@ public class JWTValidator {
     private void persistJWTID(final String jti, long expiryTime, long issuedTime, int tenantId)
             throws OAuthClientAuthnException {
 
-        jwtStorageManager.persistJWTIdInDB(jti, tenantId, expiryTime, issuedTime);
+        jwtStorageManager.persistJWTIdInDB(jti, tenantId, expiryTime, issuedTime, this.preventTokenReuse);
     }
 
     private OAuthAppDO getOAuthAppDO(String jwtSubject) throws OAuthClientAuthnException {

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
@@ -95,13 +95,19 @@ public class JWTStorageManagerTest extends PowerMockIdentityBaseTest {
     public void testPersistJWTIdInDB() throws Exception {
 
         JWTServiceDataHolder.getInstance().setPreventTokenReuse(true);
-        JWTStorageManager.persistJWTIdInDB("2023", -1234, 10000000, 10000000);
+        JWTStorageManager.persistJWTIdInDB("2023", -1234, 10000000, 10000000,true);
     }
 
     @Test(expectedExceptions = OAuthClientAuthnException.class)
     public void testPersistJWTIdInDBExceptionCase() throws Exception {
 
-        JWTStorageManager.persistJWTIdInDB("2000", -1234, 10000000, 10000000);
+        JWTStorageManager.persistJWTIdInDB("2000", -1234, 10000000, 10000000, true);
+    }
+
+    @Test
+    public void testDefaultPersistJWTIdInDB() throws Exception {
+
+        JWTStorageManager.persistJWTIdInDB("2026", -1234, 10000000, 10000000);
     }
 
     @Test()
@@ -120,11 +126,11 @@ public class JWTStorageManagerTest extends PowerMockIdentityBaseTest {
         when(JdbcUtils.isH2DB()).thenReturn(true);
         when(JdbcUtils.isOracleDB()).thenReturn(false);
         // Insert a JTI entry with Expired Date.
-        JWTStorageManager.persistJWTIdInDB("2023", 12, 10000000, 10000000);
+        JWTStorageManager.persistJWTIdInDB("2023", 12, 10000000, 10000000, false);
         when(JdbcUtils.isH2DB()).thenReturn(true);
         when(JdbcUtils.isOracleDB()).thenReturn(false);
         // Update a JTI entry again.
-        JWTStorageManager.persistJWTIdInDB("2023", 12, 10001000, 10000100);
+        JWTStorageManager.persistJWTIdInDB("2023", 12, 10001000, 10000100, false);
     }
 
     @Test(dependsOnMethods = {"testPersistJWTIdInDBWithoutTokenReuse"})

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -258,7 +258,7 @@ public class JWTValidatorTest {
                 preventTokenReuse = Boolean.parseBoolean(preventTokenReuseProperty);
             }
             JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
-            jwtClientAuthenticatorConfig.setEnableTokenReuse(preventTokenReuse);
+            jwtClientAuthenticatorConfig.setEnableTokenReuse(!preventTokenReuse);
 
             JWTAuthenticationConfigurationDAO mockDAO = Mockito.mock(JWTAuthenticationConfigurationDAO
                     .class);


### PR DESCRIPTION
## Purpose
preventTokenReuse and EnableTokenReuse are mixed up in some parts of the code, hence in some flows prevent token will be set to false even if it is intended to be true.

Here we identified all potential areas and fix them.

Tested flows:

- EnableTokenReuse = true without cache and request token with same JTI after expiration
- EnableTokenReuse = true with cache and request token with same JTI after expiration
- EnableTokenReuse = false with cache and request token with same JTI after expiration

All affected flow work as expected.