### PR TITLE
Support validation of audience values from multiple allowed audience values for PAR

### DIFF
--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -92,6 +92,7 @@ public class JWTValidatorTest {
     public static final String ENABLE_CACHE_FOR_JTI = "EnableCacheForJTI";
     public static final String MANDATORY = "mandatory";
     public static final String ID_TOKEN_ISSUER_ID = "http://localhost:9443/oauth2/token";
+    public static final String TOKEN_ENDPOINT = "https://localhost:9443/oauth2/token";
     private KeyStore clientKeyStore;
     private KeyStore serverKeyStore;
     private X509Certificate cert;
@@ -215,6 +216,7 @@ public class JWTValidatorTest {
         String jsonWebToken18 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "3011", audience, "RSA265", key1, 0);
         String jsonWebToken19 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "10010010", audience, "RSA265", key1, 0);
         String jsonWebToken20 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "10010010", audience, "RSA265", key1, 0);
+        String jsonWebToken21 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "10010011", TOKEN_ENDPOINT, "RSA265", key1, 0);
 
         return new Object[][]{
                 {jsonWebToken0, properties8, false, "Correct authentication request is failed."},
@@ -243,6 +245,7 @@ public class JWTValidatorTest {
                 {jsonWebToken19, properties1, true, "Unable to use same JTI across tenants."},
                 {jsonWebToken20, properties1, false, "Duplicated JTI was used in same tenant with " +
                         "preventTokenReuse enabled."},
+                {jsonWebToken21, properties1, true, "JWT with valid audience from the accepted value list should pass."}
         };
     }
 


### PR DESCRIPTION
## Purpose
> This PR includes the implementation to validate the audience value from a set of accepted audience values which includes the issuer identifier, token endpoint URL or pushed authorization request endpoint URL. This is a requirement in PAR as the authorization server needs to accept these audience values in order to facilitate interoperability.

## Related Issues
https://github.com/wso2/product-is/issues/16520