### PR TITLE
Avoid multiple authenticators being executed erroneously for the token endpoint

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -40,6 +40,8 @@ public class Constants {
     public static final String ISSUER_CLAIM = "iss";
     public static final String PRIVATE_KEY_JWT = "signedJWT";
     public static final String JWKS_URI = "jwksURI";
+    public static final String AUTHENTICATOR_TYPE_PARAM = "authenticatorType";
+    public static final String AUTHENTICATOR_TYPE_PK_JWT = "pkJWT";
 
     //query keys
     public static final String GET_JWT_ID = "GET_JWT_ID";

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -106,6 +106,7 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
     public boolean authenticateClient(HttpServletRequest httpServletRequest, Map<String, List> bodyParameters,
                                       OAuthClientAuthnContext oAuthClientAuthnContext) throws OAuthClientAuthnException {
 
+        oAuthClientAuthnContext.addParameter(Constants.AUTHENTICATOR_TYPE_PARAM, Constants.AUTHENTICATOR_TYPE_PK_JWT);
         return jwtValidator.isValidAssertion(getSignedJWT(bodyParameters, oAuthClientAuthnContext));
     }
 

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -107,6 +107,22 @@ public class PrivateKeyJWTClientAuthenticatorTest {
         boolean received = privateKeyJWTClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent,
                 oAuthClientAuthnContext);
         assertEquals(received, true, "A valid request refused to authenticate.");
+    }
 
+    @Test
+    public void testPrivateKeyJWTFlagAdded() {
+
+        Map<String, List> bodyContent = new HashMap<>();
+        List<String> assertionType = new ArrayList<>();
+        assertionType.add(OAUTH_JWT_BEARER_GRANT_TYPE);
+        bodyContent.put(OAUTH_JWT_ASSERTION, null);
+        bodyContent.put(OAUTH_JWT_ASSERTION_TYPE, assertionType);
+        try {
+            privateKeyJWTClientAuthenticator.authenticateClient(httpServletRequest, bodyContent,
+                    oAuthClientAuthnContext);
+        } catch (OAuthClientAuthnException e) {
+            assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
+                    Constants.AUTHENTICATOR_TYPE_PARAM));
+        }
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -180,7 +180,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
                                    OAuthClientAuthnContext context) {
 
         String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
-        if (clientIdExistsAsParam(bodyParams) || clientIdExistsAsHeader(request)) {
+        if (clientIdExistsAsParam(bodyParams) || clientIdExistsAsParameter(request)) {
             try {
                 if (!isMTLSAuthentication(request, bodyParams)) {
                     return false;
@@ -513,12 +513,12 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
     }
 
     /**
-     * Check whether the Client ID is included in the request headers.
+     * Check whether the Client ID is included in the request parameters.
      *
      * @param request     Http servlet request.
-     * @return Whether the Client ID is included in the request headers.
+     * @return Whether the Client ID is included in the request parameters.
      */
-    private boolean clientIdExistsAsHeader(HttpServletRequest request) {
+    private boolean clientIdExistsAsParameter(HttpServletRequest request) {
 
         String oauthClientID =  request.getParameter(OAuth.OAUTH_CLIENT_ID);
         return (isNotEmpty(oauthClientID));

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -52,7 +52,6 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -65,8 +64,6 @@ import java.util.Optional;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil.JAVAX_SERVLET_REQUEST_CERTIFICATE;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.MutualTLSUtil.isJwksUriConfigured;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getServiceProvider;
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
-import static org.apache.commons.lang.StringUtils.isEmpty;
 
 /**
  * This class is responsible for authenticating OAuth clients with Mutual TLS. The client will present
@@ -180,15 +177,9 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
                                    OAuthClientAuthnContext context) {
 
         String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
-        if (clientIdExistsAsParam(bodyParams) || clientIdExistsAsParameter(request)) {
-            try {
-                if (!isMTLSAuthentication(request, bodyParams)) {
-                    return false;
-                }
-            } catch (OAuthClientAuthnException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error occurred while processing the request.", e);
-                }
+        if (clientIdExistsAsParam(bodyParams)) {
+            if (CommonConstants.AUTHENTICATOR_TYPE_PK_JWT.equals((String)
+                    context.getParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM))) {
                 return false;
             }
             if (validCertExistsAsAttribute(request)) {
@@ -471,57 +462,6 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
     public String getName() {
 
         return this.getClass().getSimpleName();
-    }
-
-    /**
-     * Validate whether the request follows MTLS client authentication.
-     *
-     * @param request         Http servlet request.
-     * @param contentParam    Map of request body params.
-     * @return Whether the request follows MTLS client authentication.
-     * @throws OAuthClientAuthnException
-     */
-    private boolean isMTLSAuthentication(HttpServletRequest request, Map<String, List> contentParam)
-            throws OAuthClientAuthnException {
-
-        String mtlsAuthHeader = Optional.ofNullable(IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER))
-                .orElse("CONFIG_NOT_FOUND");
-
-        String oauthClientID =  request.getParameter(OAuth.OAUTH_CLIENT_ID);
-        if (isEmpty(oauthClientID)) {
-            oauthClientID = (String) contentParam.get(OAuth.OAUTH_CLIENT_ID).get(0);
-        }
-        try {
-            String oauthClientSecret = request.getParameter(OAuth.OAUTH_CLIENT_SECRET);
-            String oauthJWTAssertion = request.getParameter(CommonConstants.OAUTH_JWT_ASSERTION);
-            String oauthJWTAssertionType = request.getParameter(CommonConstants.OAUTH_JWT_ASSERTION_TYPE);
-            String authorizationHeader = request.getHeader(CommonConstants.AUTHORIZATION_HEADER);
-            String x509Certificate = request.getHeader(mtlsAuthHeader);
-            if (isEmpty(x509Certificate)) {
-                Certificate certificate = (Certificate) request.getAttribute(mtlsAuthHeader);
-                if (certificate != null) {
-                    x509Certificate = IdentityUtil.convertCertificateToPEM(certificate);
-                }
-            }
-            return (isNotEmpty(oauthClientID) && isEmpty(oauthClientSecret) && isEmpty(oauthJWTAssertion) &&
-                    isEmpty(oauthJWTAssertionType) && isEmpty(authorizationHeader) && x509Certificate != null &&
-                    parseCertificate(x509Certificate) != null);
-        } catch (CertificateException e) {
-            throw new OAuthClientAuthnException("Error occurred while parsing the certificate",
-                    OAuth2ErrorCodes.INVALID_REQUEST);
-        }
-    }
-
-    /**
-     * Check whether the Client ID is included in the request parameters.
-     *
-     * @param request     Http servlet request.
-     * @return Whether the Client ID is included in the request parameters.
-     */
-    private boolean clientIdExistsAsParameter(HttpServletRequest request) {
-
-        String oauthClientID =  request.getParameter(OAuth.OAUTH_CLIENT_ID);
-        return (isNotEmpty(oauthClientID));
     }
 }
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -182,6 +182,10 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
             // not authenticate the client.
             if (CommonConstants.AUTHENTICATOR_TYPE_PK_JWT.equals((String)
                     context.getParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM))) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Returning false since the PrivateKeyJWT client authenticator has already authenticated " +
+                            "the request.");
+                }
                 return false;
             }
             if (validCertExistsAsAttribute(request)) {

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -178,6 +178,8 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
         String headerName = IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER);
         if (clientIdExistsAsParam(bodyParams)) {
+            // If the Private key JWT authenticator was hit previously, then the MTLS authenticator should
+            // not authenticate the client.
             if (CommonConstants.AUTHENTICATOR_TYPE_PK_JWT.equals((String)
                     context.getParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM))) {
                 return false;

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
@@ -43,5 +43,9 @@ public class CommonConstants {
     public static final String HTTP_READ_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
             ".HTTPReadTimeout";
     public static final String KEYS = "keys";
+    public static final String OAUTH_JWT_ASSERTION = "client_assertion";
+    public static final String OAUTH_JWT_ASSERTION_TYPE = "client_assertion_type";
+    public static final String AUTHORIZATION_HEADER = "authorization";
+    public static final String OAUTH_JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/utils/CommonConstants.java
@@ -43,9 +43,7 @@ public class CommonConstants {
     public static final String HTTP_READ_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
             ".HTTPReadTimeout";
     public static final String KEYS = "keys";
-    public static final String OAUTH_JWT_ASSERTION = "client_assertion";
-    public static final String OAUTH_JWT_ASSERTION_TYPE = "client_assertion_type";
-    public static final String AUTHORIZATION_HEADER = "authorization";
     public static final String OAUTH_JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    public static final String AUTHENTICATOR_TYPE_PK_JWT = "pkJWT";
 
 }

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -237,7 +237,6 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
             + "    \"x5u\" : \"https://keystore.abc.org.lk/0015800001HQQrZAAX/CzUe1ecMKykHLhQAATzFBudOj0Y.pem\",\n"
             + "    \"x5t#S256\" : \"fMSq7nleARP8LlJGKDmYII1EjhGwBpW8BZapcCZNKSo=\"\n" + "  } ]\n" + "}";
 
-
     @DataProvider(name = "testAuthenticateClientWhenJWKSEndPointGiven")
     public Object[][] testAuthenticateClientWhenJWKSEndPointGiven() {
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -135,6 +135,7 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
             "yEBIDgcpZrD8x/Z42al6T/6EANMpvu4Jopisg+uwwkEGSM1I/kjiW+YkWC4oTZ1jMZUWC" +
             "11WbcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuA" +
             "xFtF8v+h-----END CERTIFICATE-----";
+
     private static String TEST_JSON_WITH_X5T ="{\n" +
             "  \"keys\" : [ {\n" +
             "    \"e\" : \"AQAB\",\n" +
@@ -236,13 +237,6 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
             + "    \"x5u\" : \"https://keystore.abc.org.lk/0015800001HQQrZAAX/CzUe1ecMKykHLhQAATzFBudOj0Y.pem\",\n"
             + "    \"x5t#S256\" : \"fMSq7nleARP8LlJGKDmYII1EjhGwBpW8BZapcCZNKSo=\"\n" + "  } ]\n" + "}";
 
-    private static String CLIENT_ASSERTION = "eyJraWQiOiJqeVJVY3l0MWtWQ2xjSXZsVWxjRHVrVlozdFUiLCJhbGciOiJQUzI1" +
-            "NiJ9.eyJzdWIiOiJpWXBSbTY0YjJ2bXZtS0RoZEw2S1pEOXo2ZmNhIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0My9vYXV0a" +
-            "DIvdG9rZW4iLCJpc3MiOiJpWXBSbTY0YjJ2bXZtS0RoZEw2S1pEOXo2ZmNhIiwiZXhwIjoxNjEwNjMxNDEyLCJpYXQiOjE2MTA2MDE" +
-            "0MTIsImp0aSI6IjE2MTA2MDE0MTI5MDAifQ.tmMTlCL-VABhFTA6QQ6UPvUydKuzynidepAa8oZGEBfVyAsiW5IF01NKYD0ynpXXJC" +
-            "Q6hcbWK0FEGity67p6DeI9LT-xAnaKwZY7H8rbuxWye2vhanM0jVa1vggsmwWYyOR4k55ety9lP1MkcGZpaK48qoaqsX_X7GCSGXzq" +
-            "BncTEPYfCpVUQtS4ctwoCl06TFbY2Lfm9E24z1rfmU9xPc7au6LpKRLMMHQ8QXuc-FhnWdgEFv_3tAai2ovVmrqEfwj6Z6Ew5bFeI9" +
-            "jtCR4TSol47hzDwldx5rH7m2OPUx66yEtGrM7UU62fC-4nxplZ69fjlHN4KQ62PxEaCQs0_A";
 
     @DataProvider(name = "testAuthenticateClientWhenJWKSEndPointGiven")
     public Object[][] testAuthenticateClientWhenJWKSEndPointGiven() {

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -135,6 +135,20 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
             "11WbcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuA" +
             "xFtF8v+h-----END CERTIFICATE-----";
 
+    private static String INVALID_CERT = "-----BEGIN CERTIFICATE-----MIID3" +
+            "TCCAsWgAwIBAgIUJQW8iwYsAbyjc/oHti8DPLJH5ZcwDQYJKoZIhvcNAQELBQAwfjELMA" +
+            "kGA1UEBhMCU0wxEDAOBgNVBAgMB1dlc3Rlcm4xEDAOBgNVBAcMB0NvbG9tYm8xDTALBgN" +
+            "VBAoMBFdTTzIxDDAKBgNVBAsMA0lBTTENMAsGA1UEAwwER2FnYTEfMB0GCSqGSIb3DQEJ" +
+            "ARYQZ2FuZ2FuaUB3c28yLmNvbTAeFw0yMDAzMjQxMjQyMDFaFw0zMDAzMjIxMjQyMDFaM" +
+            "H4xCzAJBgNVBAYTAlNMMRAwDgYDVQQIDAdXZXN0ZXJuMRAwDgYDVQQHDAdDb2xvbWJvMQ" +
+            "0wCwYDVQQKDARXU08yMQwwCgYDVQQLDANJQU0xDTALBgNVBAMMBEdhZ2ExHzAdBgkqhki" +
+            "G9w0BCQEWEGdhbmdhbmlAd3NvMi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK" +
+            "AoIBAQC+reCEYOn2lnWgFsp0TF0R1wQiD9C/N+dnv4xCa0rFiu4njDzWR/8tYFl0koaxX" +
+            "oP0+oGnT07KlkA66q0ztwikLZXphLdCBbJ1hSmNvor48FuSb6DgqWixrUa2LHlpaaV7Rv" +
+            "yEBIDgcpZrD8x/Z42al6T/6EANMpvu4Jopisg+uwwkEGSM1I/kjiW+YkWC4oTZ1jMZUWC" +
+            "11WbcouLwjfaf6gt4zWitYCP0r0fLGk4bSJfUFsnJNu6vDhx60TbRhIh9P2jxkmgNYPuA" +
+            "xFtF8v+h-----END CERTIFICATE-----";
+
     private static String TEST_JSON_WITH_X5T ="{\n" +
             "  \"keys\" : [ {\n" +
             "    \"e\" : \"AQAB\",\n" +
@@ -484,6 +498,18 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
                 new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(CERTIFICATE_CONTENT_2)));
         assertFalse(mutualTLSClientAuthenticator.authenticate(Cert,anotherCert));
 
+    }
+
+    @Test
+    public void testCanAuthenticateWithInvalidCert() {
+
+        mockStatic(IdentityUtil.class);
+        HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
+        when(IdentityUtil.getProperty(CommonConstants.MTLS_AUTH_HEADER)).thenReturn("x-wso2-mtls-cert");
+        PowerMockito.when(httpServletRequest.getParameter(OAuth.OAUTH_CLIENT_ID)).thenReturn(CLIENT_ID);
+        PowerMockito.when(httpServletRequest.getHeader("x-wso2-mtls-cert")).thenReturn(INVALID_CERT);
+        assertFalse(mutualTLSClientAuthenticator.canAuthenticate(httpServletRequest, new HashMap<>(), new
+                OAuthClientAuthnContext()));
     }
 
     @Test(dataProvider = "testCanAuthenticateData")

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -485,7 +485,7 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
         bodyContent.put(OAuth.OAUTH_CLIENT_ID, Arrays.asList(CLIENT_ID));
         OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
         oAuthClientAuthnContext.addParameter(CommonConstants.AUTHENTICATOR_TYPE_PARAM,
-                CommonConstants.AUTHENTICATOR_TYPE_MTLS);
+                CommonConstants.AUTHENTICATOR_TYPE_PK_JWT);
         HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
         assertFalse(mutualTLSClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent,
                 oAuthClientAuthnContext));


### PR DESCRIPTION
## Purpose
> This PR includes the implementation to check whether a private key JWT is being passed in the request and based on that result, if a private key JWT is being passed via the request then the MTLS client authentication will be omitted.

## Related Issues
https://github.com/wso2/product-is/issues/16521