### PR TITLE
Updating the identity.inbound.auth.oauth dependency version

### DIFF
--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/storage/JWTStorageManagerTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.storage;
 
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -34,7 +35,6 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTEntry
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.dao.JWTStorageManager;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import java.util.List;
 
@@ -52,7 +52,7 @@ import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.
 
 
 @PrepareForTest({IdentityUtil.class, JdbcUtils.class, IdentityDatabaseUtil.class, FrameworkUtils.class})
-public class JWTStorageManagerTest extends PowerMockIdentityBaseTest {
+public class JWTStorageManagerTest extends PowerMockTestCase {
 
     private JWTStorageManager JWTStorageManager;
     private Connection spyConnection;

--- a/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.clientauth.privilegeduser/src/test/java/org/wso2/carbon/identity/oauth2/clientauth/privilegeduser/PrivilegedUserAuthenticatorTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth2.clientauth.privilegeduser;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -28,7 +29,6 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.clientauth.privilegeduser.internal.PrivilegedUserAuthenticatorServiceHolder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserRealm;
@@ -59,7 +59,7 @@ import static org.testng.Assert.assertTrue;
         UserCoreUtil.class,
 })
 @WithCarbonHome
-public class PrivilegedUserAuthenticatorTest extends PowerMockIdentityBaseTest {
+public class PrivilegedUserAuthenticatorTest extends PowerMockTestCase {
 
     private PrivilegedUserAuthenticator privilegedUserAuthenticator = new PrivilegedUserAuthenticator();
     private static final String USERNAME = "username";

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/handlers/MTLSTokenBindingRefreshGrantHandlerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.handlers;
 
-import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
@@ -27,13 +26,11 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.utils.CommonConstants;
-import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.util.ArrayList;
@@ -44,7 +41,7 @@ import static org.testng.Assert.assertFalse;
 /**
  * Test class for MTLSTokenBindingRefreshGrantHandlerTest class.
  */
-@PrepareForTest({IdentityUtil.class, CarbonUtils.class, Oauth2ScopeUtils.class})
+@PrepareForTest({IdentityUtil.class, CarbonUtils.class})
 
 @WithCarbonHome
 public class MTLSTokenBindingRefreshGrantHandlerTest extends PowerMockTestCase {
@@ -104,13 +101,9 @@ public class MTLSTokenBindingRefreshGrantHandlerTest extends PowerMockTestCase {
         PowerMockito.when(IdentityUtil.getIdentityConfigDirPath()).thenReturn(System.
                 getProperty("user.dir") + "/src/test/resources/repository/conf/identity");
         mtlsTokenBindingRefreshGrantHandler = new MTLSTokenBindingRefreshGrantHandler();
-        mockStatic(Oauth2ScopeUtils.class);
-        PowerMockito.when(Oauth2ScopeUtils.validateByApplicationScopeValidator
-                (Matchers.any(OAuthTokenReqMessageContext.class),
-                        Matchers.any(OAuthAuthzReqMessageContext.class))).thenReturn(false);
         OAuthTokenReqMessageContext oAuthTokenReqMessageContext =
                 new OAuthTokenReqMessageContext(oauth2AccessTokenReqDTOObject());
-        oAuthTokenReqMessageContext.setScope(new String[]{"openid"});
+        oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO().setScope(new String[]{"openid"});
         boolean validateScope =
                 mtlsTokenBindingRefreshGrantHandler.validateScope(oAuthTokenReqMessageContext);
         assertFalse(validateScope);

--- a/component/org.wso2.carbon.identity.oauth2.validators.xacml/src/test/java/org/wso2/carbon/identity/oauth2/validators/XACMLScopeValidatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.validators.xacml/src/test/java/org/wso2/carbon/identity/oauth2/validators/XACMLScopeValidatorTest.java
@@ -22,6 +22,7 @@ package org.wso2.carbon.identity.oauth2.validators;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockObjectFactory;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.powermock.reflect.internal.WhiteboxImpl;
 import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeClass;
@@ -33,7 +34,6 @@ import org.wso2.balana.utils.policy.PolicyBuilder;
 import org.wso2.balana.utils.policy.dto.RequestElementDTO;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.application.common.cache.BaseCache;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.entitlement.EntitlementException;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
@@ -53,7 +53,6 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.xacml.XACMLScopeValidator;
 import org.wso2.carbon.identity.oauth2.validators.xacml.constants.XACMLScopeValidatorConstants;
 import org.wso2.carbon.identity.oauth2.validators.xacml.internal.OAuthScopeValidatorDataHolder;
-import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -71,7 +70,7 @@ import static org.testng.Assert.assertTrue;
         AuthorizationGrantCache.class})
 @PowerMockIgnore({"javax.xml.*"})
 @WithCarbonHome
-public class XACMLScopeValidatorTest extends IdentityBaseTest {
+public class XACMLScopeValidatorTest extends PowerMockTestCase {
 
     private static final String ADMIN_USER = "admin_user";
     private static final String APP_NAME = "SP_APP";

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-                <version>${carbon.identity.version}</version>
+                <version>${carbon.identity.application.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -245,7 +245,7 @@
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
-                <version>${carbon.kernel.version}</version>
+                <version>${carbon.utils.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -393,7 +393,9 @@
     <properties>
 
         <carbon.identity.version>5.20.322</carbon.identity.version>
-        <identity.inbound.auth.oauth.version>6.7.70</identity.inbound.auth.oauth.version>
+        <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
+        <carbon.utils.version>4.9.10</carbon.utils.version>
+        <identity.inbound.auth.oauth.version>6.11.119</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>
 


### PR DESCRIPTION
## Purpose
> This PR will upgrade the identity.inbound.auth.oauth dependency version used in this repository and will also resolve the unit test issues and build issues that occurred after the said dependency version was upgraded. 
>
> Below are the reasons that required a change in the unit tests.
> - With the identity.inbound.auth.oauth dependency version update, certain methods (like validateScope method in the RefreshGrantHandler class) were updated which required unit tests also to be changed accordingly. 
>
> - To resolve the class casting error from org.ops4j.pax.logging.log4jv2.Log4jv2Logger to org.apache.logging.log4j.core.Logger which was caused by the carbon.identity.testutil dependency after the other dependencies were updated. In order to fix this and use the latest carbon.identity.testutil dependency version, a whole change needs to be carried out in the tests while making the repository able to be built using Java 11.