### PR TITLE
Adding supported authentication methods for the client authenticators

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticator.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.validator.JW
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -62,6 +63,7 @@ import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Const
 public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthenticator {
 
     private static final Log log = LogFactory.getLog(PrivateKeyJWTClientAuthenticator.class);
+    private static final String PRIVATE_KEY_JWT_CLIENT_AUTHENTICATOR_AUTH_METHOD = "private_key_jwt";
     private JWTValidator jwtValidator;
 
     private int rejectBeforePeriod = DEFAULT_VALIDITY_PERIOD_IN_MINUTES;
@@ -199,5 +201,16 @@ public class PrivateKeyJWTClientAuthenticator extends AbstractOAuthClientAuthent
         mandatoryClaims.add(EXPIRATION_TIME_CLAIM);
         mandatoryClaims.add(JWT_ID_CLAIM);
         return mandatoryClaims;
+    }
+
+    /**
+     * Retrieve the authentication methods supported by the authenticator.
+     *
+     * @return      Authentication methods supported by the authenticator.
+     */
+    @Override
+    public List<String> getSupportedClientAuthenticationMethods() {
+
+        return Arrays.asList(PRIVATE_KEY_JWT_CLIENT_AUTHENTICATOR_AUTH_METHOD);
     }
 }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -342,7 +342,7 @@ public class JWTValidator {
         String message = String.format("Error while retrieving OAuth application with provided JWT information with " +
                 "subject '%s' ", jwtSubject);
         try {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientIdOnly(jwtSubject);
+            oAuthAppDO = OAuth2Util.getAppInformationByClientId(jwtSubject);
             if (oAuthAppDO == null) {
                 logAndThrowException(message);
             }

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -342,7 +342,7 @@ public class JWTValidator {
         String message = String.format("Error while retrieving OAuth application with provided JWT information with " +
                 "subject '%s' ", jwtSubject);
         try {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientId(jwtSubject);
+            oAuthAppDO = OAuth2Util.getAppInformationByClientIdOnly(jwtSubject);
             if (oAuthAppDO == null) {
                 logAndThrowException(message);
             }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.reflect.internal.WhiteboxImpl;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
@@ -155,5 +156,13 @@ public class PrivateKeyJWTClientAuthenticatorTest {
             assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
                     Constants.AUTHENTICATOR_TYPE_PARAM));
         }
+    }
+
+    @Test
+    public void testGetSupportedClientAuthenticationMethods() {
+
+        List<String> supportedAuthMethods = privateKeyJWTClientAuthenticator.getSupportedClientAuthenticationMethods();
+        Assert.assertTrue(supportedAuthMethods.contains("private_key_jwt"));
+        assertEquals(supportedAuthMethods.size(), 1);
     }
 }

--- a/component/client-handler/src/test/resources/dbscripts/identity.sql
+++ b/component/client-handler/src/test/resources/dbscripts/identity.sql
@@ -167,7 +167,7 @@ INSERT INTO IDN_OIDC_JTI (JWT_ID,TENANT_ID,EXP_TIME,TIME_CREATED)VALUES ('100100
 
 INSERT INTO IDN_OAUTH_CONSUMER_APPS (ID, CONSUMER_KEY, CONSUMER_SECRET, USERNAME, TENANT_ID, USER_DOMAIN, APP_NAME,
             OAUTH_VERSION, CALLBACK_URL, GRANT_TYPES, APP_STATE) VALUES
-            (2, 'KrVLov4Bl3natUksF2HmWsdw684a', 'testSecret1', 'testUser', 1234, 'PRIMARY',
+            (2, 'KrVLov4Bl3natUksF2HmWsdw684a', 'testSecret1', 'testUser', -1234, 'PRIMARY',
             'myApp', 'OAuth-2.0', 'http://localhost:8080/redirect',
             'refresh_token password iwa:ntlm client_credentials', 'ACTIVE');
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -56,6 +56,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,7 @@ import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getServiceProvider
 public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticator {
 
     private static final Log log = LogFactory.getLog(MutualTLSClientAuthenticator.class);
+    private static final String MTLS_CLIENT_AUTHENTICATOR_AUTH_METHOD = "tls_client_auth";
 
     /**
      * @param request                 HttpServletRequest which is the incoming request.
@@ -468,6 +470,17 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
     public String getName() {
 
         return this.getClass().getSimpleName();
+    }
+
+    /**
+     * Retrieve the authentication methods supported by the authenticator.
+     *
+     * @return      Authentication methods supported by the authenticator.
+     */
+    @Override
+    public List<String> getSupportedClientAuthenticationMethods() {
+
+        return Arrays.asList(MTLS_CLIENT_AUTHENTICATOR_AUTH_METHOD);
     }
 }
 

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticatorTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -489,6 +490,14 @@ public class MutualTLSClientAuthenticatorTest extends PowerMockTestCase {
         HttpServletRequest httpServletRequest = PowerMockito.mock(HttpServletRequest.class);
         assertFalse(mutualTLSClientAuthenticator.canAuthenticate(httpServletRequest, bodyContent,
                 oAuthClientAuthnContext));
+    }
+
+    @Test
+    public void testGetSupportedClientAuthenticationMethods() {
+
+        List<String> supportedAuthMethods = mutualTLSClientAuthenticator.getSupportedClientAuthenticationMethods();
+        Assert.assertTrue(supportedAuthMethods.contains("tls_client_auth"));
+        assertEquals(supportedAuthMethods.size(), 1);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>6.11.119</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.136</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
-                <version>${carbon.identity.version}</version>
+                <version>${org.wso2.carbon.identity.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -396,6 +396,7 @@
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
         <identity.inbound.auth.oauth.version>6.11.136</identity.inbound.auth.oauth.version>
+        <org.wso2.carbon.identity.core.version>5.25.383</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>
 


### PR DESCRIPTION
## Purpose
> This PR includes the implementation to retrieve the authenticator supported authentication methods that is being used in the server configurations.
Ex: PrivateKeyJWTClientAuthenticator supports private_key_jwt, MutualTLSClientAuthenticator supports tls_client_auth
>
> In addition to it in this PR the versions have been upgraded of the identity.inbound.auth.oauth and org.wso2.carbon.identity.core dependencies as below.
identity.inbound.auth.oauth - from 6.11.119 to 6.11.136
org.wso2.carbon.identity.core - from 5.20.322 to 5.25.383

## Related Issues
https://github.com/wso2/product-is/issues/16921