### PR TITLE
Improving error handling in the JWTValidator

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -126,7 +126,7 @@ public class JWTValidator {
 
         if (signedJWT == null) {
             errorMessage = "No valid JWT assertion found for " + Constants.OAUTH_JWT_BEARER_GRANT_TYPE;
-            return logAndThrowException(errorMessage);
+            return logAndThrowException(errorMessage, OAuth2ErrorCodes.INVALID_REQUEST);
         }
         try {
             JWTClaimsSet claimsSet = getClaimSet(signedJWT);
@@ -216,8 +216,10 @@ public class JWTValidator {
 
             return true;
 
-        } catch (IdentityOAuth2Exception | UserStoreException | JWTClientAuthenticatorServiceServerException e) {
-            return logAndThrowException(e.getMessage());
+        } catch (IdentityOAuth2Exception e) {
+            return logAndThrowException(e.getMessage(), e.getErrorCode());
+        } catch (UserStoreException | JWTClientAuthenticatorServiceServerException e) {
+            return logAndThrowException(e.getMessage(), OAuth2ErrorCodes.INVALID_REQUEST);
         }
     }
 
@@ -226,7 +228,7 @@ public class JWTValidator {
         for (String mandatoryClaim : mandatoryClaims) {
             if (claimsSet.getClaim(mandatoryClaim) == null) {
                 String errorMessage = "Mandatory field :" + mandatoryClaim + " is missing in the JWT assertion.";
-                return logAndThrowException(errorMessage);
+                return logAndThrowException(errorMessage, OAuth2ErrorCodes.INVALID_REQUEST);
             }
         }
         return true;
@@ -326,7 +328,7 @@ public class JWTValidator {
             return true;
         } else if (preventTokenReuse) {
             String message = "JWT Token with JTI: " + jti + " has been replayed.";
-            return logAndThrowException(message);
+            return logAndThrowException(message, OAuth2ErrorCodes.INVALID_REQUEST);
         }
         // Token reuse is allowed. Here we are logging whether the token is reused within the allowed expiry time.
         if (currentTimeInMillis + timeStampSkewMillis < jwtEntry.getExp()) {
@@ -376,20 +378,20 @@ public class JWTValidator {
         try {
             oAuthAppDO = OAuth2Util.getAppInformationByClientId(jwtSubject);
             if (oAuthAppDO == null) {
-                logAndThrowException(message);
+                logAndThrowException(message, OAuth2ErrorCodes.INVALID_REQUEST);
             }
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-            logAndThrowException(message);
+            logAndThrowException(message, OAuth2ErrorCodes.INVALID_REQUEST);
         }
         return oAuthAppDO;
     }
 
-    private boolean logAndThrowException(String detailedMessage) throws OAuthClientAuthnException {
+    private boolean logAndThrowException(String detailedMessage, String errorCode) throws OAuthClientAuthnException {
 
         if (log.isDebugEnabled()) {
             log.debug(detailedMessage);
         }
-        throw new OAuthClientAuthnException(detailedMessage, OAuth2ErrorCodes.INVALID_REQUEST);
+        throw new OAuthClientAuthnException(detailedMessage, errorCode);
     }
 
     private boolean validateJWTWithExpTime(Date expTime, long currentTimeInMillis, long timeStampSkewMillis)

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -388,10 +388,7 @@ public class JWTValidator {
 
     private boolean logAndThrowException(String detailedMessage) throws OAuthClientAuthnException {
 
-        if (log.isDebugEnabled()) {
-            log.debug(detailedMessage);
-        }
-        throw new OAuthClientAuthnException(detailedMessage, OAuth2ErrorCodes.INVALID_REQUEST);
+        return logAndThrowException(detailedMessage, OAuth2ErrorCodes.INVALID_REQUEST);
     }
 
     private boolean logAndThrowException(String detailedMessage, String errorCode) throws OAuthClientAuthnException {


### PR DESCRIPTION
## Purpose
> This PR includes the implementation to improve the logAndThrowException() method to accept the error code as well with the error message so that the method can be used in any place with the relevant error code without overwriting the original error code.
