### PR TITLE
Check for private keys in DPoP proofs

### DIFF
--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
@@ -171,17 +171,15 @@ public class DPoPHeaderValidator {
             if (!header.getJWK().isPrivate()) {
                 return true;
             }
-            String error = "Private key is used in the DPoP Proof header.";
             if (log.isDebugEnabled()) {
-                log.debug(error);
+                log.debug("Private key is used in the DPoP Proof header.");
             }
-            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_PROOF +" : " + error);
+            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_ERROR);
         }
-        String error = "'jwk' is not presented in the DPoP Proof header";
         if (log.isDebugEnabled()) {
-            log.debug(error);
+            log.debug("'jwk' is not presented in the DPoP Proof header");
         }
-        throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_PROOF +" : " + error);
+        throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_ERROR);
     }
 
     private static boolean checkAlg(JWSHeader header) throws IdentityOAuth2ClientException {

--- a/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.dpop/src/main/java/org/wso2/carbon/identity/dpop/validators/DPoPHeaderValidator.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.dpop.validators;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -165,13 +166,22 @@ public class DPoPHeaderValidator {
 
     private static boolean checkJwk(JWSHeader header) throws IdentityOAuth2ClientException {
 
-        if (header.getJWK() == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("'jwk' is not presented in the DPoP Proof header");
+        JWK jwk = header.getJWK();
+        if (jwk != null) {
+            if (!header.getJWK().isPrivate()) {
+                return true;
             }
-            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_ERROR);
+            String error = "Private key is used in the DPoP Proof header.";
+            if (log.isDebugEnabled()) {
+                log.debug(error);
+            }
+            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_PROOF +" : " + error);
         }
-        return true;
+        String error = "'jwk' is not presented in the DPoP Proof header";
+        if (log.isDebugEnabled()) {
+            log.debug(error);
+        }
+        throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, DPoPConstants.INVALID_DPOP_PROOF +" : " + error);
     }
 
     private static boolean checkAlg(JWSHeader header) throws IdentityOAuth2ClientException {


### PR DESCRIPTION
parent issue : https://github.com/wso2/product-is/issues/16606

**Description:**
The latest specification for DPoP (Distributed Proof of Possession) mandate few additional conditions to be met  when validating DPoP proof headers . To ensure full compliance with the specification, we need to implement checks for these  conditions.
one of those additional conditions is **Checking for Private Keys in JWK Parameter of DPoP Proof Header:**
   - The JWK (JSON Web Key) parameter within the DPoP proof header should not contain a private key.
  
This PR implements checking for presence of private keys in JWK parameter.
 