### PR TITLE
[MTLS] Remove all whitespaces in the certificate before decoding

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -280,7 +280,6 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
                 .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY);
         // Removing all whitespaces and new lines.
         certBody = certBody.replaceAll("\\s", "");
-
         byte[] decoded = Base64.getDecoder().decode(certBody);
 
         return (java.security.cert.X509Certificate) CertificateFactory.getInstance(CommonConstants.X509)

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -275,12 +275,13 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
 
         // Trim extra spaces.
         String decodedContent = StringUtils.trim(content);
-
         // Remove Certificate Headers.
-        byte[] decoded = Base64.getDecoder().decode(StringUtils.trim(decodedContent
-                .replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
-                .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY)
-        ));
+        String certBody = decodedContent.replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
+                .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY);
+        // Removing all whitespaces and new lines.
+        certBody = certBody.replaceAll("\\s", "");
+
+        byte[] decoded = Base64.getDecoder().decode(certBody);
 
         return (java.security.cert.X509Certificate) CertificateFactory.getInstance(CommonConstants.X509)
                 .generateCertificate(new ByteArrayInputStream(decoded));


### PR DESCRIPTION
## Purpose
There is a bug in `MutualTLSClientAuthenticator` when decoding the certificates passed via a header which contains whitespaces and newlines. This throws a 500 server error. This PR removes all whitespaces before decoding.

## Related Issues
Public Git Issue: https://github.com/wso2/product-is/issues/20229