### PR TITLE
[MTLS] Remove unnecessary newline character from certificate coming as a header

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -279,7 +279,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
         String certBody = decodedContent.replaceAll(CommonConstants.BEGIN_CERT, StringUtils.EMPTY)
                 .replaceAll(CommonConstants.END_CERT, StringUtils.EMPTY);
         // Removing all whitespaces and new lines.
-        certBody = certBody.replaceAll("\\s", "");
+        certBody = certBody.replaceAll("\\s", StringUtils.EMPTY).replace("\\n", StringUtils.EMPTY);
         byte[] decoded = Base64.getDecoder().decode(certBody);
 
         return (java.security.cert.X509Certificate) CertificateFactory.getInstance(CommonConstants.X509)


### PR DESCRIPTION
### Purpose
There is a bug in `MutualTLSClientAuthenticator` when decoding the certificates passed via a header which contains newline characters. This throws a 500 server error. This PR removes `\n` before decoding.

### Related Issues
Public Git Issue: https://github.com/wso2/product-is/issues/20229