### PR TITLE
[MTLS] Decode utf-8 url encoded certs when passing from header

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -281,6 +281,7 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
         try {
             decoded = Base64.getDecoder().decode(sanitizedCertificate);
         } catch (IllegalArgumentException e) {
+            log.debug("Error while base64 decoding the certificate. Trying URL decoding first.");
             String urlDecodedContent = URLDecoder.decode(content, StandardCharsets.UTF_8.name());
             sanitizedCertificate = sanitizeCertificate(urlDecodedContent);
             decoded = Base64.getDecoder().decode(sanitizedCertificate);

--- a/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
+++ b/component/org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/mutualtls/MutualTLSClientAuthenticator.java
@@ -275,6 +275,9 @@ public class MutualTLSClientAuthenticator extends AbstractOAuthClientAuthenticat
      */
     private X509Certificate parseCertificate(String content) throws CertificateException, UnsupportedEncodingException {
 
+        if (log.isDebugEnabled()) {
+            log.debug("Trying to parse the client certificate: " + content);
+        }
         byte[] decoded;
         String sanitizedCertificate = sanitizeCertificate(content);
         // First we try to Base64 decode, if it is not decodable, we try to url decode first and then Base64 decode.


### PR DESCRIPTION
## Purpose
> When a client certificate is utf-8 url encoded and sent as a header to IS, a 500 server error comes. This PR fixes this by checking if encoded and decode if yes.
