### PR TITLE
Handle no client authentication method selected scenario

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -207,7 +207,14 @@ public class JWTValidator {
             }
 
             if (oAuthAppDO.isTokenEndpointAllowReusePvtKeyJwt() != null) {
+                // Private ket JWT is selected as the token endpoint authentication method.
                 preventTokenReuse = !oAuthAppDO.isTokenEndpointAllowReusePvtKeyJwt();
+            } else {
+                // No client authentication method is selected. -> All methods are allowed.
+                preventTokenReuse = !JWTServiceDataHolder.getInstance()
+                        .getPrivateKeyJWTAuthenticationConfigurationDAO()
+                        .getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(tenantDomain)
+                        .isEnableTokenReuse();
             }
 
             //Validate signature validation, audience, nbf,exp time, jti.
@@ -225,7 +232,7 @@ public class JWTValidator {
 
         } catch (IdentityOAuth2Exception e) {
             return logAndThrowException(e.getMessage(), e.getErrorCode());
-        } catch (UserStoreException e) {
+        } catch (UserStoreException | JWTClientAuthenticatorServiceServerException e) {
             return logAndThrowException(e.getMessage());
         }
     }


### PR DESCRIPTION
Purpose
> $subject

When no client authentication method is selected, all client authentication methods are considered as selected. The new application config is only sending the value when private key jwt is selected. In this effort we are setting the org level value for such a case.
