### PR TITLE
[IS 7.1] Add FAPI 2.0 audience changes

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
     public static final String AUTHENTICATOR_TYPE_PK_JWT = "pkJWT";
     public static final String OAUTH2_PAR_URL_REF = "OAuth2ParEPUrl";
     public static final String OAUTH2_PAR_URL_CONFIG = "OAuth.OAuth2ParEPUrl";
+    public static final String FAPI2 = "2";
 
     //query keys
     public static final String GET_JWT_ID = "GET_JWT_ID";

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -69,6 +69,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -92,6 +93,7 @@ public class JWTValidator {
     public static final String PS = "PS";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
     private static final String PROP_ID_TOKEN_ISSUER_ID = "OAuth.OpenIDConnect.IDTokenIssuerID";
+    private static final String PROP_FAPI_VERSION = "OAuth.OpenIDConnect.FAPI.FAPIVersion";
     private static final String FAPI_SIGNATURE_ALG_CONFIGURATION = "OAuth.OpenIDConnect.FAPI." +
             "AllowedSignatureAlgorithms.AllowedSignatureAlgorithm";
     private static final String MTLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
@@ -165,10 +167,22 @@ public class JWTValidator {
                 return false;
             }
 
-            /* A list of valid audiences (issuer identifier, token endpoint URL or pushed authorization request
-            endpoint URL) should be supported for PAR and not just a single valid audience.
-            https://datatracker.ietf.org/doc/html/rfc9126 */
-            List<String> acceptedAudienceList = getValidAudiences(tenantDomain, requestUrl);
+            List<String> acceptedAudienceList;
+            try {
+                if (OAuth2Util.isFapiConformantApp(consumerKey) &&
+                        Constants.FAPI2.equals(IdentityUtil.getProperty(PROP_FAPI_VERSION))) {
+                    acceptedAudienceList = Collections.singletonList(IdentityUtil.getProperty(PROP_ID_TOKEN_ISSUER_ID));
+                } else {
+                /* A list of valid audiences (issuer identifier, token endpoint URL or pushed authorization request
+                endpoint URL) should be supported for PAR and not just a single valid audience.
+                https://datatracker.ietf.org/doc/html/rfc9126 */
+                    acceptedAudienceList = getValidAudiences(tenantDomain, requestUrl);
+                }
+            } catch (InvalidOAuthClientException e) {
+                throw new OAuthClientAuthnException("Error occurred while retrieving client information.",
+                        OAuth2ErrorCodes.INVALID_CLIENT);
+            }
+
 
             long expTime = 0;
             long issuedTime = 0;
@@ -218,7 +232,7 @@ public class JWTValidator {
             }
 
             //Validate signature validation, audience, nbf,exp time, jti.
-            if (!validateAudience(acceptedAudienceList, audience)
+            if (!validateAudienceFormat(audience, consumerKey) || !validateAudience(acceptedAudienceList, audience)
                     || !validateJWTWithExpTime(expirationTime, currentTimeInMillis, timeStampSkewMillis)
                     || !validateNotBeforeClaim(currentTimeInMillis, timeStampSkewMillis, nbf)
                     || !validateAgeOfTheToken(issuedAtTime, currentTimeInMillis, timeStampSkewMillis)
@@ -296,6 +310,34 @@ public class JWTValidator {
                 log.debug(errorMessage);
             }
             throw new OAuthClientAuthnException(error, OAuth2ErrorCodes.INVALID_REQUEST);
+        }
+        return true;
+    }
+
+    /**
+     * Validate 'aud' claim format. Multiple audiences are not allowed in FAPI 2.0 compliant applications.
+     *
+     * @param audience - List of audience values in the 'aud' claim of the JWT.
+     * @param consumerKey - OAuth client id of the application.
+     * @return true if the audience format is valid.
+     *
+     * @throws OAuthClientAuthnException Throw OAuthClientAuthnException if the audience format is invalid.
+     */
+    private boolean validateAudienceFormat(List<String> audience, String consumerKey) throws OAuthClientAuthnException {
+
+        try {
+            if (OAuth2Util.isFapiConformantApp(consumerKey) &&
+                    Constants.FAPI2.equals(IdentityUtil.getProperty(PROP_FAPI_VERSION))) {
+                if (audience.size() > 1) {
+                    log.debug("Multiple audience values in client assertion are not allowed for " +
+                            "FAPI 2.0 applications.");
+                    throw new OAuthClientAuthnException("Client assertion contains multiple audience values.",
+                            OAuth2ErrorCodes.INVALID_REQUEST);
+                }
+            }
+        } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+            throw new OAuthClientAuthnException("Error occurred while retrieving client information.",
+                    OAuth2ErrorCodes.INVALID_CLIENT);
         }
         return true;
     }


### PR DESCRIPTION
This PR adds the client assertion audience related changes required for the FAPI 2.0 compliance for IS 7.1.
Following changes have been introduced:
- Accept only the id-token-issuer-id as the audience for private_key_jwt validations for FAPI 2.0 applications.
- Reject client-assertions which contain multiple audience values for FAPI 2.0 applications.

issue: https://github.com/wso2/product-is/issues/25863
