### PR TITLE
[IS 5.11] Fix bugs related to private key JWT when prevent token reuse is disable related flows

### DIFF
--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/dao/JWTStorageManager.java
@@ -97,8 +97,8 @@ public class JWTStorageManager {
             prepStmt.setString(1, jti);
             rs = prepStmt.executeQuery();
             if (rs.next()) {
-                long exp = rs.getTime(1, Calendar.getInstance(TimeZone.getTimeZone(Constants.UTC))).getTime();
-                long created = rs.getTime(2, Calendar.getInstance(TimeZone.getTimeZone(Constants.UTC))).getTime();
+                long exp = rs.getTimestamp(1, Calendar.getInstance(TimeZone.getTimeZone(Constants.UTC))).getTime();
+                long created = rs.getTimestamp(2, Calendar.getInstance(TimeZone.getTimeZone(Constants.UTC))).getTime();
                 jwtEntry = new JWTEntry(exp, created);
             }
         } catch (SQLException e) {

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -273,7 +273,7 @@ public class JWTValidator {
 
         if (currentTimeInMillis + timeStampSkewMillis < jwtExpiryTimeMillis) {
             if (log.isDebugEnabled()) {
-                log.debug("JWT Token with jti: " + jti + "has been reused with in the allowed expiry time: " +
+                log.debug("JWT Token with jti: " + jti + " has been reused within the allowed expiry time: " +
                         jwtExpiryTimeMillis);
             }
             return true;

--- a/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -254,46 +254,31 @@ public class JWTValidator {
             }
         }
         // Check JWT ID in DB
-        if (!validateJWTInDataBase(jti, currentTimeInMillis, timeStampSkewMillis)) {
-            return false;
-        }
-        persistJWTID(jti, expTime, issuedTime);
-        return true;
-    }
-
-    private boolean validateJWTInDataBase(String jti, long currentTimeInMillis,
-                                          long timeStampSkewMillis) throws OAuthClientAuthnException {
-
         JWTEntry jwtEntry = jwtStorageManager.getJwtFromDB(jti);
         if (jwtEntry == null) {
             if (log.isDebugEnabled()) {
                 log.debug("JWT id: " + jti + " not found in the Storage the JWT has been validated successfully.");
             }
+            persistJWTID(jti, expTime, issuedTime);
             return true;
         } else if (preventTokenReuse) {
-            if (jwtStorageManager.isJTIExistsInDB(jti)) {
-                String message = "JWT Token with JTI: " + jti + " has been replayed";
-                return logAndThrowException(message);
-            }
-        } else {
-            if (!checkJTIValidityPeriod(jti, jwtEntry.getExp(), currentTimeInMillis, timeStampSkewMillis)) {
-                return false;
-            }
+            logAndThrowException("JWT Token with JTI: " + jti + " has been replayed");
         }
+        checkJTIValidityPeriod(jti, jwtEntry.getExp(), currentTimeInMillis, timeStampSkewMillis);
         return true;
     }
 
     private boolean checkJTIValidityPeriod(String jti, long jwtExpiryTimeMillis, long currentTimeInMillis,
                                            long timeStampSkewMillis) throws OAuthClientAuthnException {
 
-        if (currentTimeInMillis + timeStampSkewMillis > jwtExpiryTimeMillis) {
+        if (currentTimeInMillis + timeStampSkewMillis < jwtExpiryTimeMillis) {
             if (log.isDebugEnabled()) {
-                log.debug("JWT Token with jti: " + jti + "has been reused after the allowed expiry time: " +
+                log.debug("JWT Token with jti: " + jti + "has been reused with in the allowed expiry time: " +
                         jwtExpiryTimeMillis);
             }
             return true;
         } else {
-            String message = "JWT Token with jti: " + jti + " has been replayed before the allowed expiry time: "
+            String message = "JWT Token with jti: " + jti + " has been replayed after the allowed expiry time: "
                     + jwtExpiryTimeMillis;
             return logAndThrowException(message);
         }

--- a/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/component/client-handler/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -228,7 +228,7 @@ public class JWTValidatorTest {
                         "."},
                 {jsonWebToken11, properties1, false, ""},
                 {jsonWebToken12, properties5, true, ""},
-                {jsonWebToken12, properties5, false, ""},
+                {jsonWebToken12, properties5, true, ""},
                 {jsonWebToken13, properties1, false, ""},
                 {jsonWebToken15, properties1, false, ""},
                 {jsonWebToken16, properties4, false, ""},


### PR DESCRIPTION
### Public PR
- https://github.com/wso2-extensions/identity-oauth-addons/pull/103

#### Related Issues
- https://github.com/wso2/product-is/issues/26705

The suggested improvement is a behaviour change as explained 
- https://github.com/wso2/product-is/issues/15603

Previously, the documentation stated that a JWT could be reused after its expiry. However, this is incorrect. A JWT must be reused before the token expires.

Even if a client attempts to reuse a JWT after it has expired, the request will fail because the corresponding JTI is already registered in the IDN_OIDC_JTI table. Therefore, the previously documented behavior would not have worked in practice.

Additionally, there is a JTI cleanup script that periodically removes expired JTIs from the IDN_OIDC_JTI table. Once these entries are cleaned, the previously used JTIs are removed from the table. However, this still does not allow the reuse of the JWT, since the token itself is already expired and will be rejected during validation.

Therefore, regardless of the cleanup process, an expired JWT cannot be used again. This confirms that the previously documented flow was not functionally valid. As a result, the proposed improvement can be introduced without requiring any additional configuration, since it aligns with the actual behavior of the system.

## Purpose
This pull request refactors the JWT replay and expiry validation logic to improve correctness and clarity. The main changes include adjustments to how JWT expiry and creation times are retrieved from the database, updates to the replay prevention logic, and corrections to the expiry validation condition. Test cases have also been updated to reflect the new logic.

**JWT Replay and Expiry Validation Improvements:**

* Changed retrieval of expiry and creation times in `JWTStorageManager.java` from `getTime` to `getTimestamp` to ensure accurate time handling for JWT entries.
* Refactored the JWT replay and expiry validation logic in `JWTValidator.java`:
  * Simplified the flow by removing the separate `validateJWTInDataBase` method and integrating its logic directly.
  * Updated the replay prevention logic to throw an exception immediately if a JWT with the same JTI exists and replay prevention is enabled.
  * Corrected the expiry validation condition in `checkJTIValidityPeriod` to use `<` instead of `>`, ensuring that JWTs are only considered valid within their allowed expiry time.
  * Improved debug and error messages for clarity regarding JWT replay and expiry.

**Test Updates:**

* Modified test cases in `JWTValidatorTest.java` to align with the new validation logic, ensuring tests accurately reflect the expected outcomes for JWT replay and expiry scenarios.